### PR TITLE
Implement NetcdfDataWriter

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
     windows_x64 ("net.adoptopenjdk:jre:11.0.6_10@zip")
     windows_x64 ("mil.army.usace.hec:javaHeclib:7-IP-win-x86_64@zip")
     windows_x64 ("org.gdal:gdal:3.2.1-win-x64@zip")
+    windows_x64 ("edu.ucar:netcdf:4.9.2:win-x64@zip")
     linux_x64("net.adoptopenjdk:jre:11.0.9_10-linux64@tar.gz")
     linux_x64("mil.army.usace.hec:javaHeclib:7-IP-linux-x86_64@zip")
     macOS_x64("net.adoptium:jre:11.0.15_10:macOS-x64@zip")
@@ -312,17 +313,9 @@ tasks.register<Copy>("getNatives") {
         }
     }
     else if(OperatingSystem.current().isMacOsX()) {
-        if(System.getProperty("os.arch") == "aarch64") {
-            configurations.getByName("macOS_aarch64").asFileTree.forEach() {
-                from(zipTree(it))
-                into("$projectDir/bin")
-            }
-        }
-        else {
-            configurations.getByName("macOS_x64").asFileTree.forEach() {
-                from(zipTree(it))
-                into("$projectDir/bin")
-            }
+        configurations.getByName("macOS_x64").asFileTree.forEach() {
+            from(zipTree(it))
+            into("$projectDir/bin")
         }
     }
 

--- a/calculator/package/windows/calculator.bat
+++ b/calculator/package/windows/calculator.bat
@@ -1,4 +1,4 @@
-SET "PATH=.\gdal;%PATH%"
+SET "PATH=.\gdal;.\netcdf;%PATH%"
 SET "GDAL_DATA=.\gdal\gdal-data"
 SET "PROJ_LIB=.\gdal\projlib"
 "..\jre\bin\java.exe" --module-path "..\jmods" --add-modules javafx.controls,javafx.fxml -Djavafx.cachedir=. -Djava.library.path=".;.\gdal" -cp ..\lib\calculator.jar;..\lib\* calculator.CalculatorWizard

--- a/clipper/package/windows/clipper.bat
+++ b/clipper/package/windows/clipper.bat
@@ -1,4 +1,4 @@
-SET "PATH=.\gdal;%PATH%"
+SET "PATH=.\gdal;.\netcdf;%PATH%"
 SET "GDAL_DATA=.\gdal\gdal-data"
 SET "PROJ_LIB=.\gdal\projlib"
 "..\jre\bin\java.exe" --module-path "..\jmods" --add-modules javafx.controls,javafx.fxml -Djavafx.cachedir=. -Djava.library.path=".;.\gdal" -cp ..\lib\clipper.jar;..\lib\* clipper.ClipperWizard

--- a/grid-to-point-converter/package/windows/grid-to-point-converter.bat
+++ b/grid-to-point-converter/package/windows/grid-to-point-converter.bat
@@ -1,4 +1,4 @@
-SET "PATH=.\gdal;%PATH%"
+SET "PATH=.\gdal;.\netcdf;%PATH%"
 SET "GDAL_DATA=.\gdal\gdal-data"
 SET "PROJ_LIB=.\gdal\projlib"
 "..\jre\bin\java.exe" --module-path "..\jmods" --add-modules javafx.controls,javafx.fxml -Djavafx.cachedir=. -Djava.library.path=".;.\gdal" -cp ..\lib\grid-to-point-converter.jar;..\lib\* converter.ConverterWizard

--- a/image-exporter/package/windows/image-exporter.bat
+++ b/image-exporter/package/windows/image-exporter.bat
@@ -1,4 +1,4 @@
-SET "PATH=.\gdal;%PATH%"
+SET "PATH=.\gdal;.\netcdf;%PATH%"
 SET "GDAL_DATA=.\gdal\gdal-data"
 SET "PROJ_LIB=.\gdal\projlib"
 "..\jre\bin\java.exe" --module-path "..\jmods" --add-modules javafx.controls,javafx.fxml -Djavafx.cachedir=. -Djava.library.path=".;.\gdal" -cp ..\lib\image-exporter.jar;..\lib\* image.exporter.ImageExporterWizard

--- a/importer/package/windows/importer.bat
+++ b/importer/package/windows/importer.bat
@@ -1,4 +1,4 @@
-SET "PATH=.\gdal;%PATH%"
+SET "PATH=.\gdal;.\netcdf;%PATH%"
 SET "GDAL_DATA=.\gdal\gdal-data"
 SET "PROJ_LIB=.\gdal\projlib"
 "..\jre\bin\java.exe" --module-path "..\jmods" --add-modules javafx.controls,javafx.fxml -Djavafx.cachedir=. -Djava.library.path=".;.\gdal" -cp ..\lib\importer.jar;..\lib\* importer.MetDataImportWizard

--- a/normalizer/package/windows/normalizer.bat
+++ b/normalizer/package/windows/normalizer.bat
@@ -1,4 +1,4 @@
-SET "PATH=.\gdal;%PATH%"
+SET "PATH=.\gdal;.\netcdf;%PATH%"
 SET "GDAL_DATA=.\gdal\gdal-data"
 SET "PROJ_LIB=.\gdal\projlib"
 "..\jre\bin\java.exe" --module-path "..\jmods" --add-modules javafx.controls,javafx.fxml -Djavafx.cachedir=. -Djava.library.path=".;.\gdal" -cp ..\lib\normalizer.jar;..\lib\* normalizer.NormalizerWizard

--- a/sanitizer/package/windows/sanitizer.bat
+++ b/sanitizer/package/windows/sanitizer.bat
@@ -1,4 +1,4 @@
-SET "PATH=.\gdal;%PATH%"
+SET "PATH=.\gdal;.\netcdf;%PATH%"
 SET "GDAL_DATA=.\gdal\gdal-data"
 SET "PROJ_LIB=.\gdal\projlib"
 "..\jre\bin\java.exe" --module-path "..\jmods" --add-modules javafx.controls,javafx.fxml -Djavafx.cachedir=. -Djava.library.path=".;.\gdal" -cp ..\lib\sanitizer.jar;..\lib\* sanitizer.SanitizerWizard

--- a/time-shifter/package/windows/time-shifter.bat
+++ b/time-shifter/package/windows/time-shifter.bat
@@ -1,4 +1,4 @@
-SET "PATH=.\gdal;%PATH%"
+SET "PATH=.\gdal;.\netcdf;%PATH%"
 SET "GDAL_DATA=.\gdal\gdal-data"
 SET "PROJ_LIB=.\gdal\projlib"
 "..\jre\bin\java.exe" --module-path "..\jmods" --add-modules javafx.controls,javafx.fxml -Djavafx.cachedir=. -Djava.library.path=".;.\gdal" -cp ..\lib\time-shifter.jar;..\lib\* shifter.ShifterWizard

--- a/transposer/package/windows/transposer.bat
+++ b/transposer/package/windows/transposer.bat
@@ -1,4 +1,4 @@
-SET "PATH=.\gdal;%PATH%"
+SET "PATH=.\gdal;.\netcdf;%PATH%"
 SET "GDAL_DATA=.\gdal\gdal-data"
 SET "PROJ_LIB=.\gdal\projlib"
 "..\jre\bin\java.exe" --module-path "..\jmods" --add-modules javafx.controls,javafx.fxml -Djavafx.cachedir=. -Djava.library.path=".;.\gdal" -cp ..\lib\transposer.jar;..\lib\* transposer.TransposerWizard

--- a/vortex-api/build.gradle.kts
+++ b/vortex-api/build.gradle.kts
@@ -11,6 +11,12 @@ repositories {
 }
 
 dependencies {
+    implementation("edu.ucar:netcdf4")
+    constraints {
+        implementation("edu.ucar:netcdf4:5.5.3")
+        runtimeOnly("net.java.dev.jna:jna:5.13.0")
+    }
+    
     implementation("mil.army.usace.hec:hec-monolith:3.+") {
         isTransitive = false
     }
@@ -20,14 +26,13 @@ dependencies {
     implementation("org.locationtech.jts:jts-core:1.16.1")
     implementation("tech.units:indriya:2.0.4")
     implementation("systems.uom:systems-common:2.0.2")
-    implementation("edu.ucar:cdm-core:5.5.2")
+    implementation("edu.ucar:cdm-core:5.5.3")
     implementation("org.apache.commons:commons-compress:1.20")
     //start runtime-only deps required by HEC shared libraries
     runtimeOnly("com.google.flogger:flogger:0.7.4")
     runtimeOnly("com.google.flogger:flogger-system-backend:0.7.4")
     //end runtime-only deps required by HEC shared libraries
-    runtimeOnly("edu.ucar:grib:5.5.2")
-    runtimeOnly("edu.ucar:netcdf4:5.5.2")
+    runtimeOnly("edu.ucar:grib:5.5.3")
     runtimeOnly("org.slf4j:slf4j-simple:1.7.25")
     testImplementation("org.mockito:mockito-core:2.27.0")
     testImplementation("org.junit.jupiter:junit-jupiter:5.4.2")
@@ -44,7 +49,7 @@ tasks.test {
 
     if (org.gradle.internal.os.OperatingSystem.current().isWindows()) {
         environment = mapOf(
-            "PATH" to "${rootProject.projectDir}/bin/gdal",
+            "PATH" to "${rootProject.projectDir}/bin/gdal;${rootProject.projectDir}/bin/netcdf",
             "GDAL_DRIVER_PATH" to "${rootProject.projectDir}/bin/gdal/gdal/gdalplugins",
             "GDAL_DATA" to "${rootProject.projectDir}/bin/gdal/gdal-data",
             "PROJ_LIB" to "${rootProject.projectDir}/bin/gdal/projlib"

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/VortexDataType.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/VortexDataType.java
@@ -1,0 +1,35 @@
+package mil.army.usace.hec.vortex;
+
+public enum VortexDataType {
+    INSTANTANEOUS("INST-VAL", "point"),
+    ACCUMULATION("PER-CUM", "sum"),
+    AVERAGE("PER-AVER", "mean"),
+    UNDEFINED("", "");
+
+    // https://www.hec.usace.army.mil/confluence/display/dssJavaprogrammer/Units+and+Type
+    private final String dssString;
+
+    // https://cfconventions.org/cf-conventions/cf-conventions.html#cell-methods
+    private final String ncString;
+
+    VortexDataType(String dssString, String ncString) {
+        this.dssString = dssString;
+        this.ncString = ncString;
+    }
+
+    public static VortexDataType fromString(String dataTypeString) {
+        for (VortexDataType type : values()) {
+            if (dataTypeString.equals(type.getDssString()) || dataTypeString.equals(type.getNcString()))
+                return type;
+        }
+        throw new IllegalArgumentException("dataTypeString not recognized");
+    }
+
+    public String getDssString() {
+        return dssString;
+    }
+
+    public String getNcString() {
+        return ncString;
+    }
+}

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/VortexGridCollection.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/VortexGridCollection.java
@@ -1,0 +1,224 @@
+package mil.army.usace.hec.vortex;
+
+import mil.army.usace.hec.vortex.io.NetcdfGridWriter;
+import mil.army.usace.hec.vortex.geo.WktParser;
+import ucar.nc2.constants.CF;
+import ucar.unidata.geoloc.LatLonPoint;
+import ucar.unidata.geoloc.Projection;
+import ucar.unidata.geoloc.ProjectionPoint;
+import ucar.unidata.geoloc.projection.LatLonProjection;
+import ucar.unidata.util.Parameter;
+
+import java.time.Duration;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.*;
+import java.util.logging.Logger;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+public class VortexGridCollection {
+    private static final Logger logger = Logger.getLogger(VortexGridCollection.class.getName());
+
+    private final List<VortexGrid> vortexGridList;
+    private final VortexGrid defaultGrid;
+    private final ZonedDateTime baseTime;
+
+    public VortexGridCollection(List<VortexGrid> vortexGrids) {
+        vortexGridList = vortexGrids;
+        defaultGrid = !vortexGridList.isEmpty() ? vortexGrids.get(0) : null;
+        baseTime = initBaseTime();
+        cleanCollection();
+    }
+
+    /* Init */
+    private ZonedDateTime initBaseTime() {
+        return ZonedDateTime.of(1900,1,1,0,0,0,0, ZoneId.of("UTC"));
+    }
+
+    private void cleanCollection() {
+        String shortName = defaultGrid.shortName();
+        String wkt = defaultGrid.wkt();
+        Duration interval = defaultGrid.interval();
+
+        if (shortName.isEmpty()) logger.warning("Short name not found");
+        if (wkt.isEmpty()) logger.warning("Wkt not found");
+        if (interval.equals(Duration.ZERO)) logger.warning("Interval not found");
+
+        vortexGridList.removeIf(g -> !Objects.equals(shortName, g.shortName()));
+        vortexGridList.removeIf(g -> !Objects.equals(wkt, g.wkt()));
+        vortexGridList.removeIf(g -> !Objects.equals(interval, g.interval()));
+    }
+
+    /* Conditionals */
+    public boolean isGeographic() {
+        return getProjection() instanceof LatLonProjection;
+    }
+
+    public boolean hasTimeBounds() {
+        return !getInterval().isZero();
+    }
+
+    /* Data */
+    public Stream<Map.Entry<Integer, VortexGrid>> getCollectionDataStream() {
+        return IntStream.range(0, vortexGridList.size()).parallel().mapToObj(i -> Map.entry(i, vortexGridList.get(i)));
+    }
+
+    public float getNoDataValue() {
+        return (float) defaultGrid.noDataValue();
+    }
+
+    public String getDataUnit() {
+        return defaultGrid.units();
+    }
+
+    public VortexDataType getDataType() {
+        return defaultGrid.dataType();
+    }
+
+    /* Name & Description */
+    public String getShortName() {
+        return defaultGrid.shortName();
+    }
+
+    public String getDescription() {
+        return defaultGrid.description();
+    }
+
+    /* Projection */
+    public Projection getProjection() {
+        return WktParser.getProjection(getWkt());
+    }
+
+    public String getProjectionName() {
+        Projection projection = getProjection();
+        for (Parameter parameter : projection.getProjectionParameters()) {
+            if (parameter.getName().equals(CF.GRID_MAPPING_NAME)) {
+                return parameter.getStringValue();
+            }
+        }
+        return null;
+    }
+
+    public String getProjectionUnit() {
+        return WktParser.getProjectionUnit(getWkt());
+    }
+
+    public String getWkt() {
+        return defaultGrid.wkt();
+    }
+
+    /* Y and X */
+    public double[] getYCoordinates() {
+        return defaultGrid.yCoordinates();
+    }
+
+    public double[] getXCoordinates() {
+        return defaultGrid.xCoordinates();
+    }
+
+    public int getNy() {
+        return defaultGrid.ny();
+    }
+
+    public int getNx() {
+        return defaultGrid.nx();
+    }
+
+    /* Lat & Lon */
+    public Map<String, double[][]> getLatLonCoordinates() {
+        Map<String, double[][]> latLonMap = new HashMap<>();
+
+        int ny = getNy();
+        int nx = getNx();
+        double[] yCoordinates = getYCoordinates();
+        double[] xCoordinates = getXCoordinates();
+        Projection projection = getProjection();
+
+        double[][] latData = new double[ny][nx];
+        double[][] lonData = new double[ny][nx];
+
+        for (int y = 0; y < ny; y++) {
+            for (int x = 0; x < nx; x++) {
+                ProjectionPoint point = ProjectionPoint.create(xCoordinates[x], yCoordinates[y]);
+                LatLonPoint latlonPoint = projection.projToLatLon(point);
+                latData[y][x] = latlonPoint.getLatitude();
+                lonData[y][x] = latlonPoint.getLongitude();
+            }
+        }
+
+        latLonMap.put("lat", latData);
+        latLonMap.put("lon", lonData);
+
+        return latLonMap;
+    }
+
+    /* Time */
+    public int getTimeLength() {
+        return vortexGridList.size();
+    }
+
+    public String getTimeUnits() {
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss XXX");
+        String durationUnit = getDurationUnit(getBaseDuration()).toString();
+        return durationUnit + " since " + baseTime.format(dateTimeFormatter);
+    }
+
+    public float[] getTimeData() {
+        if (vortexGridList.size() == 1) {
+            return new float[] {getNumDurationsFromBaseTime(vortexGridList.get(0).endTime())};
+        }
+
+        int numData = vortexGridList.size();
+        float[] timeData = new float[numData];
+        for (int i = 0; i < numData; i++) {
+            VortexGrid grid = vortexGridList.get(i);
+            float startTime = getNumDurationsFromBaseTime(grid.startTime());
+            float endTime = getNumDurationsFromBaseTime(grid.endTime());
+            float midTime = (startTime + endTime) / 2;
+            timeData[i] = midTime;
+        }
+
+        return timeData;
+    }
+
+    public float[][] getTimeBoundsArray() {
+        float[][] timeBoundArray = new float[getTimeLength()][NetcdfGridWriter.BOUNDS_LEN];
+
+        for (int i = 0; i < vortexGridList.size(); i++) {
+            VortexGrid grid = vortexGridList.get(i);
+            float startTime = getNumDurationsFromBaseTime(grid.startTime());
+            float endTime = getNumDurationsFromBaseTime(grid.endTime());
+            timeBoundArray[i][0] = startTime;
+            timeBoundArray[i][1] = endTime;
+        }
+
+        return timeBoundArray;
+    }
+
+    public Duration getInterval() {
+        return defaultGrid.interval();
+    }
+
+    /* Helpers */
+    private float getNumDurationsFromBaseTime(ZonedDateTime dateTime) {
+        ZonedDateTime zDateTime = dateTime.withZoneSameInstant(ZoneId.of("Z"));
+        Duration durationBetween = Duration.between(baseTime, zDateTime);
+        Duration divisor = getBaseDuration();
+        return durationBetween.dividedBy(divisor);
+    }
+
+    private ChronoUnit getDurationUnit(Duration duration) {
+        if (duration.toDays() > 0) return ChronoUnit.DAYS;
+        if (duration.toHours() > 0) return ChronoUnit.HOURS;
+        if (duration.toMinutes() > 0) return ChronoUnit.MINUTES;
+        return ChronoUnit.SECONDS;
+    }
+
+    private Duration getBaseDuration() {
+        Duration interval = getInterval();
+        return interval.isZero() ? Duration.ofHours(1) : interval;
+    }
+}

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/VortexVariable.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/VortexVariable.java
@@ -1,0 +1,146 @@
+package mil.army.usace.hec.vortex;
+
+import java.util.Arrays;
+
+// long names taken from https://cfconventions.org/Data/cf-standard-names/current/build/cf-standard-name-table.html
+public enum VortexVariable {
+    PRECIPITATION("precipitation", "lwe_thickness_of_precipitation_amount","PRECIPITATION"),
+    PRESSURE("pressure", "air_pressure", "PRESSURE"),
+    TEMPERATURE("temperature", "air_temperature", "TEMPERATURE"),
+    SOLAR_RADIATION("solar radiation", "surface_downwelling_shortwave_flux_in_air", "SOLAR RADIATION"),
+    WINDSPEED("windspeed", "wind_speed", "WINDSPEED"),
+    SWE("swe", "lwe_thickness_of_surface_snow_amount", "SWE"),
+    SNOWFALL_ACCUMULATION("snowfall accumulation", "lwe_thickness_of_snowfall_amount", "SNOWFALL ACCUMULATION"),
+    ALBEDO("albedo", "surface_albedo", "ALBEDO"),
+    SNOW_DEPTH("snow depth", "surface_snow_thickness", "SNOW DEPTH"),
+    LIQUID_WATER("liquid water", "lwe_thickness_of_snowfall_amount", "LIQUID WATER"),
+    SNOW_SUBLIMATION("snow sublimation", "surface_snow_sublimation_amount", "SNOW SUBLIMATION"),
+    COLD_CONTENT("cold content", "cold_content", "COLD CONTENT"),
+    COLD_CONTENT_ATI("cold content ati", "cold_content_ati", "COLD CONTENT ATI"),
+    MELTRATE_ATI("meltrate ati", "meltrate_ati", "MELTRATE ATI"),
+    SNOW_MELT("snow melt", "surface_snow_melt_amount", "SNOW MELT"),
+    UNDEFINED("", "", "");
+
+    private final String shortName;
+    private final String longName;
+    private final String dssName;
+
+    VortexVariable(String shortName, String longName, String dssName) {
+        this.shortName = shortName;
+        this.longName = longName;
+        this.dssName = dssName;
+    }
+
+    public static VortexVariable fromDssName(String dssName) {
+        return Arrays.stream(VortexVariable.values())
+                .filter(n -> n.dssName.equals(dssName))
+                .findFirst()
+                .orElse(UNDEFINED);
+    }
+
+    public String getShortName() {
+        return shortName;
+    }
+
+    public String getLongName() {
+        return longName;
+    }
+
+    public String getDssName() {
+        return dssName;
+    }
+
+    public static VortexVariable fromName(String name) {
+        if (name == null || name.isEmpty()) return UNDEFINED;
+        name = name.toLowerCase().replaceAll("\\s", "");
+        if (isValidPrecipitationName(name)) return PRECIPITATION;
+        if (isValidPressureName(name)) return PRESSURE;
+        if (isValidTemperatureName(name)) return TEMPERATURE;
+        if (isValidSolarRadiationName(name)) return SOLAR_RADIATION;
+        if (isValidWindSpeedName(name)) return WINDSPEED;
+        if (isValidSWEName(name)) return SWE;
+        if (isValidSnowfallAccumulationName(name)) return SNOWFALL_ACCUMULATION;
+        if (isValidAlbedoName(name)) return ALBEDO;
+        if (isValidSnowDepthName(name)) return SNOW_DEPTH;
+        if (isValidLiquidWaterName(name)) return LIQUID_WATER;
+        if (isValidSnowSublimationName(name)) return SNOW_SUBLIMATION;
+        if (isValidColdContentName(name)) return COLD_CONTENT;
+        if (isValidColdContentATIName(name)) return COLD_CONTENT_ATI;
+        if (isValidMeltrateATIName(name)) return MELTRATE_ATI;
+        if (isValidSnowMeltName(name)) return SNOW_MELT;
+        return UNDEFINED;
+    }
+
+    private static boolean isValidPrecipitationName(String shortName) {
+        return shortName.contains("precipitation")
+                || shortName.contains("precip")
+                || shortName.contains("precip") && shortName.contains("rate")
+                || shortName.contains("qpe01h")
+                || shortName.contains("var209-6")
+                || shortName.contains("rainfall")
+                || shortName.equals("pr");
+    }
+
+    private static boolean isValidPressureName(String shortName) {
+        return shortName.contains("pressure") && shortName.contains("surface");
+    }
+
+    private static boolean isValidTemperatureName(String shortName) {
+        return shortName.contains("temperature")
+                || shortName.equals("airtemp")
+                || shortName.equals("tasmin")
+                || shortName.equals("tasmax")
+                || shortName.equals("temp-air");
+    }
+
+    private static boolean isValidSolarRadiationName(String shortName) {
+        return (shortName.contains("short") && shortName.contains("wave") || shortName.contains("solar"))
+                && shortName.contains("radiation");
+    }
+
+    private static boolean isValidWindSpeedName(String shortName) {
+        return shortName.contains("wind") && shortName.contains("speed");
+    }
+
+    private static boolean isValidSWEName(String shortName) {
+        return shortName.contains("snow") && shortName.contains("water") && shortName.contains("equivalent")
+                || shortName.equals("swe");
+    }
+
+    private static boolean isValidSnowfallAccumulationName(String shortName) {
+        return shortName.contains("snowfall") && shortName.contains("accumulation");
+    }
+
+    private static boolean isValidAlbedoName(String shortName) {
+        return shortName.contains("albedo");
+    }
+
+    private static boolean isValidSnowDepthName(String shortName) {
+        return shortName.contains("snow") && shortName.contains("depth");
+    }
+
+    private static boolean isValidLiquidWaterName(String shortName) {
+        return shortName.contains("snow") && shortName.contains("melt") && shortName.contains("runoff")
+                || shortName.equals("liquid water");
+    }
+
+    private static boolean isValidSnowSublimationName(String shortName) {
+        return shortName.contains("snow") && shortName.contains("sublimation");
+    }
+
+    private static boolean isValidColdContentName(String shortName) {
+        return shortName.equals("cold content");
+    }
+
+    private static boolean isValidColdContentATIName(String shortName) {
+        return shortName.equals("cold content ati");
+    }
+
+    private static boolean isValidMeltrateATIName(String shortName) {
+        return shortName.equals("meltrate ati");
+    }
+
+    private static boolean isValidSnowMeltName(String shortName) {
+        return shortName.equals("snow melt");
+    }
+}

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/geo/ReferenceUtils.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/geo/ReferenceUtils.java
@@ -64,14 +64,24 @@ public class ReferenceUtils {
         if (grid1.dy() != grid2.dy()){
             valid.set(false);
         }
-        SpatialReference sr1 = new SpatialReference(grid1.wkt());
-        SpatialReference sr2 = new SpatialReference(grid1.wkt());
 
-        if (sr1.IsSame(sr2) != 1){
+        if (!equals(grid1.wkt(), grid2.wkt())) {
             valid.set(false);
         }
 
         return valid.get();
+    }
+
+    public static boolean equals(String wkt1, String wkt2) {
+        SpatialReference sr1 = new SpatialReference(wkt1);
+        SpatialReference sr2 = new SpatialReference(wkt2);
+
+        boolean isSame = sr1.IsSame(sr2) != 1;
+
+        sr1.delete();
+        sr2.delete();
+
+        return isSame;
     }
 
     public static boolean isShg(GridInfo info){

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/geo/Resampler.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/geo/Resampler.java
@@ -95,12 +95,10 @@ public class Resampler {
     public static ResamplerBuilder builder(){return new ResamplerBuilder();}
 
     public VortexGrid resample(){
-        SpatialReference envSrs;
+        SpatialReference envSrs = new SpatialReference();
         if (envWkt != null) {
-            envSrs = new SpatialReference(envWkt);
+            envSrs.ImportFromWkt(envWkt);
             envSrs.MorphFromESRI();
-        } else {
-            envSrs = new SpatialReference();
         }
 
         Dataset dataset = RasterUtils.getDatasetFromVortexGrid(grid);

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/geo/WktParser.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/geo/WktParser.java
@@ -1,0 +1,232 @@
+package mil.army.usace.hec.vortex.geo;
+
+import org.gdal.osr.SpatialReference;
+import ucar.unidata.geoloc.Earth;
+import ucar.unidata.geoloc.Projection;
+import ucar.unidata.geoloc.projection.*;
+import ucar.unidata.geoloc.projection.proj4.LambertConformalConicEllipse;
+
+public class WktParser {
+    private WktParser() {
+        // Private empty constructor for utility class
+    }
+
+    public static Projection getProjection(String wkt) {
+        Projection defaultProjection = new LatLonProjection();
+        if (wkt == null || wkt.isEmpty()) return defaultProjection;
+        SpatialReference srs = new SpatialReference(wkt);
+
+        try {
+            if (srs.IsGeographic() == 1) return parseLatLong(srs);
+            String projectionType = srs.GetAttrValue("PROJECTION");
+            if (projectionType.matches("(?i).*albers.*conic.*equal.*area.*"))
+                return parseAlbersEqualArea(srs);
+            if (projectionType.matches("(?i).*lambert.*conformal.*conic.*"))
+                return parseLambertConformalConic(srs);
+            if (projectionType.matches("(?i).*lambert.*conformal.*"))
+                return parseLambertConformal(srs);
+            if (projectionType.matches("(?i).*orthographic.*"))
+                return parseOrthographic(srs);
+            if (projectionType.matches("(?i).*sinusoidal.*"))
+                return parseSinusoidal(srs);
+            if (projectionType.matches("(?i).*stereographic"))
+                return parseStereographic(srs);
+            if (projectionType.matches("(?i).*rotated.*pole.*"))
+                return parseRotatedPole(srs);
+            if (projectionType.matches("(?i).*transverse.*mercator.*"))
+                return parseTransverseMercator(srs);
+            if (projectionType.matches("(?i).*mercator.*"))
+                return parseMercator(srs);
+        } finally {
+            srs.delete();
+        }
+
+        return defaultProjection;
+    }
+
+    public static String getProjectionUnit(String wkt) {
+        SpatialReference srs = new SpatialReference(wkt);
+        String unitName = srs.GetLinearUnitsName().toLowerCase();
+        switch (unitName) {
+            case "meter":
+            case "metre":
+                return "m";
+            default:
+                return unitName;
+        }
+    }
+
+    private static Projection parseLatLong(SpatialReference srs) {
+        String projString = srs.ExportToProj4();
+        if (projString.contains("+o_lon_p") && projString.contains("+o_lat_p"))
+            return parseRotatedPole(srs);
+
+        Earth earth = getEarth(srs);
+        return new LatLonProjection(earth);
+    }
+
+    private static Projection parseAlbersEqualArea(SpatialReference srs) {
+        return new AlbersEqualArea(
+                getCenterLatitude(srs),
+                getCenterLongitude(srs),
+                getStandardParallel1(srs),
+                getStandardParallel2(srs),
+                getFalseEasting(srs),
+                getFalseNorthing(srs),
+                getRadiusKm(srs)
+        );
+    }
+
+    private static Projection parseLambertConformalConic(SpatialReference srs) {
+        return new LambertConformalConicEllipse(
+                getCenterLatitude(srs),
+                getCenterLongitude(srs),
+                getStandardParallel1(srs),
+                getStandardParallel2(srs),
+                getFalseEasting(srs),
+                getFalseNorthing(srs),
+                getEarth(srs)
+        );
+    }
+
+    private static Projection parseLambertConformal(SpatialReference srs) {
+        return new LambertConformal(
+                getCenterLatitude(srs),
+                getCenterLongitude(srs),
+                getStandardParallel1(srs),
+                getStandardParallel2(srs),
+                getFalseEasting(srs),
+                getFalseNorthing(srs),
+                getRadiusKm(srs)
+        );
+    }
+
+    private static Projection parseOrthographic(SpatialReference srs) {
+        return new Orthographic(
+                getCenterLatitude(srs),
+                getCenterLongitude(srs),
+                getRadiusKm(srs)
+        );
+    }
+
+    private static Projection parseSinusoidal(SpatialReference srs) {
+        return new Sinusoidal(
+                getCenterLongitude(srs),
+                getFalseEasting(srs),
+                getFalseNorthing(srs),
+                getRadiusKm(srs)
+        );
+    }
+    private static Projection parseStereographic(SpatialReference srs) {
+        return new Stereographic(
+                getCenterLatitude(srs),
+                getCenterLongitude(srs),
+                getScaleFactor(srs), // Double-check
+                getFalseEasting(srs),
+                getFalseNorthing(srs)
+        );
+    }
+
+    private static Projection parseRotatedPole(SpatialReference srs) {
+        double[] northLatLon = getNorthLatLon(srs);
+        return new RotatedPole(
+                northLatLon[0],
+                northLatLon[1]
+        );
+    }
+
+    private static Projection parseTransverseMercator(SpatialReference srs) {
+        return new TransverseMercator(
+                getCenterLatitude(srs),
+                getCenterLongitude(srs), // Double-check
+                getScaleFactor(srs), // Double-check
+                getFalseEasting(srs),
+                getFalseNorthing(srs),
+                getRadiusKm(srs)
+        );
+    }
+
+    private static Projection parseMercator(SpatialReference srs) {
+        return new Mercator(
+                getCenterLongitude(srs),
+                getStandardParallel(srs), // Double-check
+                getFalseEasting(srs),
+                getFalseNorthing(srs)
+        );
+    }
+
+    /* Extract from SpatialReference */
+    private static double getCenterLatitude(SpatialReference srs) {
+        double ogrValue = srs.GetProjParm("latitude_of_center");
+        double esriValue = srs.GetProjParm("latitude_of_origin");
+        return getValidValue(ogrValue, esriValue);
+    }
+
+    private static double getCenterLongitude(SpatialReference srs) {
+        double ogrValue = srs.GetProjParm("longitude_of_center");
+        double esriValue = srs.GetProjParm("central_meridian");
+        return getValidValue(ogrValue, esriValue);
+    }
+
+    private static double getFalseEasting(SpatialReference srs) {
+        return srs.GetProjParm("false_easting");
+    }
+
+    private static double getFalseNorthing(SpatialReference srs) {
+        return srs.GetProjParm("false_northing");
+    }
+
+    private static double getStandardParallel(SpatialReference srs) {
+        return srs.GetProjParm("standard_parallel");
+    }
+
+    private static double getStandardParallel1(SpatialReference srs) {
+        return srs.GetProjParm("standard_parallel_1");
+    }
+
+    private static double getStandardParallel2(SpatialReference srs) {
+        return srs.GetProjParm("standard_parallel_2");
+    }
+
+    private static double getRadiusKm(SpatialReference srs) {
+        return srs.GetSemiMajor() / 1000;
+    }
+
+    private static double getScaleFactor(SpatialReference srs) {
+        return srs.GetProjParm("scale_factor");
+    }
+
+    private static double[] getNorthLatLon(SpatialReference srs) {
+        String projString = srs.ExportToProj4();
+        String originLatKey = "+o_lat_p=";
+        String originLonKey = "+lon_0=";
+
+        double[] latLon = new double[2];
+        for (String param : projString.split("\\s+")) {
+            if (param.startsWith(originLatKey)) {
+                double oLatP = Double.parseDouble(param.substring(originLatKey.length()));
+                latLon[0] = oLatP;
+            }
+            if (param.startsWith(originLonKey)) {
+                double oLonP = Double.parseDouble(param.substring(originLonKey.length()));
+                latLon[1] = oLonP - 180;
+            }
+        }
+
+        return latLon;
+    }
+
+    private static Earth getEarth(SpatialReference srs) {
+        double semiMajor = srs.GetSemiMajor();
+        double semiMinor = srs.GetSemiMinor();
+        double inverseFlattening = srs.GetInvFlattening();
+        return new Earth(semiMajor, semiMinor, inverseFlattening);
+    }
+
+    private static double getValidValue(double... values) {
+        for (double value : values)
+            if (value != 0)
+                return value;
+        return Double.NaN;
+    }
+}

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/BatchImporter.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/BatchImporter.java
@@ -4,26 +4,24 @@ import mil.army.usace.hec.vortex.Options;
 
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
+import java.nio.file.FileSystems;
 import java.nio.file.Path;
+import java.nio.file.PathMatcher;
 import java.nio.file.Paths;
-import java.time.Duration;
-import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.logging.Logger;
 
-public class BatchImporter {
-    private static final Logger logger = Logger.getLogger(BatchImporter.class.getName());
+public abstract class BatchImporter {
     private final List<String> inFiles;
     private final List<String> variables;
-    private final Path destination;
-    private final Map<String, String> geoOptions;
-    private final Map<String, String> writeOptions;
+    final Path destination;
+    final Map<String, String> geoOptions;
+    final Map<String, String> writeOptions;
 
     private final PropertyChangeSupport support;
     private final AtomicInteger doneCount;
 
-    private BatchImporter(Builder builder){
+    BatchImporter(Builder builder) {
         this.inFiles = builder.inFiles;
         this.variables = builder.variables;
         this.destination = builder.destination;
@@ -40,70 +38,79 @@ public class BatchImporter {
         private final Map<String, String> geoOptions = new HashMap<>();
         private final Map<String, String> writeOptions = new HashMap<>();
 
-        public Builder inFiles(final List<String> inFiles){
+        public Builder inFiles(final List<String> inFiles) {
             this.inFiles = inFiles;
             return this;
         }
 
-        public Builder variables(final List<String> variables){
+        public Builder variables(final List<String> variables) {
             this.variables = variables;
             return this;
         }
 
-        public Builder destination(final String destination){
+        public Builder destination(final String destination) {
             this.destination = Paths.get(destination);
             return this;
         }
 
         /**
-         * @deprecated since 0.10.16, replaced by {@link #geoOptions}
-         * @param geoOptions  the geographic options
+         * @param geoOptions the geographic options
          * @return the builder
+         * @deprecated since 0.10.16, replaced by {@link #geoOptions}
          */
         @Deprecated
-        public Builder geoOptions(final Options geoOptions){
+        public Builder geoOptions(final Options geoOptions) {
             Optional.ofNullable(geoOptions).ifPresent(o -> this.geoOptions.putAll(o.getOptions()));
             return this;
         }
 
-        public Builder geoOptions(final Map<String, String> geoOptions){
+        public Builder geoOptions(final Map<String, String> geoOptions) {
             this.geoOptions.putAll(geoOptions);
             return this;
         }
 
         /**
-         * @deprecated since 0.10.16, replaced by {@link #writeOptions}
-         * @param writeOptions  the file write options
+         * @param writeOptions the file write options
          * @return the builder
+         * @deprecated since 0.10.16, replaced by {@link #writeOptions}
          */
         @Deprecated
-        public Builder writeOptions(final Options writeOptions){
+        public Builder writeOptions(final Options writeOptions) {
             Optional.ofNullable(writeOptions).ifPresent(o -> this.writeOptions.putAll(o.getOptions()));
             return this;
         }
 
-        public Builder writeOptions(Map<String, String> writeOptions){
+        public Builder writeOptions(Map<String, String> writeOptions) {
             this.writeOptions.putAll(writeOptions);
             return this;
         }
 
-        public BatchImporter build(){
-            return new BatchImporter(this);
+        private boolean isConcurrentWritable() {
+            PathMatcher concurrentMatcher = FileSystems.getDefault().getPathMatcher("glob:**/*.{dss,asc,tiff}");
+            return concurrentMatcher.matches(destination);
+        }
+
+        public BatchImporter build() {
+            if (destination == null) throw new IllegalStateException("Invalid destination.");
+
+            if (isConcurrentWritable()) return new ConcurrentBatchImporter(this);
+            else return new SerialBatchImporter(this);
         }
     }
 
-    public static Builder builder() {return new Builder();}
+    public static Builder builder() {
+        return new Builder();
+    }
 
-    public void process() {
-        Instant start = Instant.now();
-        List<ImportableUnit> importableUnits = new ArrayList<>();
+    public abstract void process();
+
+    List<DataReader> getDataReaders() {
+        List<DataReader> readers = new ArrayList<>();
 
         inFiles.forEach(file -> {
-            List<DataReader> readers = new ArrayList<>();
             if (DataReader.isVariableRequired(file)) {
                 variables.forEach(variable -> {
                     if (DataReader.getVariables(file).contains(variable)) {
-
                         DataReader reader = DataReader.builder()
                                 .path(file)
                                 .variable(variable)
@@ -119,35 +126,24 @@ public class BatchImporter {
 
                 readers.add(reader);
             }
-
-            readers.forEach(reader -> {
-                ImportableUnit importableUnit = ImportableUnit.builder()
-                        .reader(reader)
-                        .geoOptions(geoOptions)
-                        .destination(destination)
-                        .writeOptions(writeOptions)
-                        .build();
-
-                importableUnits.add(importableUnit);
-            });
         });
 
-        int totalCount = importableUnits.size();
+        return readers;
+    }
 
-        importableUnits.parallelStream().forEach(importableUnit -> {
-            importableUnit.addPropertyChangeListener(evt -> {
-                if(evt.getPropertyName().equals("complete")) {
-                    int newValue = (int) (((float) doneCount.incrementAndGet() / totalCount) * 100);
-                    support.firePropertyChange("progress", null, newValue);
-                }
-            });
+    PropertyChangeListener writeProgressListener(int totalCount) {
+        return evt -> {
+            // Propagating Write Progress to UI
+            if (evt.getPropertyName().equals(DataWriter.WRITE_COMPLETED)) {
+                int newValue = (int) (((float) doneCount.incrementAndGet() / totalCount) * 100);
+                support.firePropertyChange("progress", null, newValue);
+            }
 
-            importableUnit.process();
-        });
-        Duration duration = Duration.between(start, Instant.now());
-        long seconds = duration.toSeconds();
-
-        logger.info(String.format("Batch import time: %d:%02d:%02d%n", seconds / 3600, (seconds % 3600) / 60, (seconds % 60)));
+            // Propagating Write Error to UI
+            if (evt.getPropertyName().equals(DataWriter.WRITE_ERROR)) {
+                support.firePropertyChange(evt);
+            }
+        };
     }
 
     public void addPropertyChangeListener(PropertyChangeListener pcl) {

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/ConcurrentBatchImporter.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/ConcurrentBatchImporter.java
@@ -1,0 +1,40 @@
+package mil.army.usace.hec.vortex.io;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+class ConcurrentBatchImporter extends BatchImporter {
+    private static final Logger logger = Logger.getLogger(ConcurrentBatchImporter.class.getName());
+
+    ConcurrentBatchImporter(Builder builder) {
+        super(builder);
+    }
+
+    @Override
+    public void process() {
+        Instant start = Instant.now();
+
+        List<ImportableUnit> importableUnits = getDataReaders().stream()
+                .map(reader -> ImportableUnit.builder()
+                        .reader(reader)
+                        .geoOptions(geoOptions)
+                        .destination(destination)
+                        .writeOptions(writeOptions)
+                        .build())
+                .collect(Collectors.toList());
+
+        int totalCount = importableUnits.size();
+
+        importableUnits.parallelStream().forEach(importableUnit -> {
+            importableUnit.addPropertyChangeListener(writeProgressListener(totalCount));
+            importableUnit.process();
+        });
+
+        long seconds = Duration.between(start, Instant.now()).toSeconds();
+        String timeMessage = String.format("Batch import time: %d:%02d:%02d%n", seconds / 3600, (seconds % 3600) / 60, (seconds % 60));
+        logger.info(timeMessage);
+    }
+}

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/DssDataReader.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/DssDataReader.java
@@ -1,6 +1,7 @@
 package mil.army.usace.hec.vortex.io;
 
 import hec.heclib.dss.DSSPathname;
+import hec.heclib.dss.DssDataType;
 import hec.heclib.dss.HecDSSDataAttributes;
 import hec.heclib.dss.HecDSSFileAccess;
 import hec.heclib.dss.HecDssCatalog;
@@ -51,14 +52,14 @@ class DssDataReader extends DataReader {
             GridData gridData = new GridData();
             griddedData.retrieveGriddedData(true, gridData, status);
             if (status[0] == 0) {
-                dtos.add(dssToDto(gridData));
+                dtos.add(dssToDto(gridData, path));
             }
 
         });
         return dtos;
     }
 
-    private VortexGrid dssToDto(GridData gridData){
+    private VortexGrid dssToDto(GridData gridData, String pathname){
         GridInfo gridInfo = gridData.getGridInfo();
         String wkt = WktFactory.fromGridInfo(gridInfo);
         float cellSize = gridInfo.getCellSize();
@@ -94,6 +95,8 @@ class DssDataReader extends DataReader {
 
         float[] data = MatrixUtils.flipArray(gridData.getData(), nx, ny);
 
+        String dssTypeString = DssDataType.fromInt(gridInfo.getDataType()).toString();
+
         return  VortexGrid.builder()
                 .dx(cellSize)
                 .dy(-cellSize)
@@ -111,6 +114,7 @@ class DssDataReader extends DataReader {
                 .startTime(startTime)
                 .endTime(endTime)
                 .interval(interval)
+                .dataType(dssTypeString)
                 .build();
     }
 
@@ -173,7 +177,7 @@ class DssDataReader extends DataReader {
         int[] status = new int[1];
         GridData gridData = GridUtilities.retrieveGridFromDss(this.path, dssPath, status);
         if (gridData != null) {
-            return dssToDto(gridData);
+            return dssToDto(gridData, dssPath);
         }
         return null;
     }

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/DssDataWriter.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/DssDataWriter.java
@@ -13,6 +13,7 @@ import hec.io.TimeSeriesContainer;
 import mil.army.usace.hec.vortex.VortexGrid;
 import mil.army.usace.hec.vortex.VortexPoint;
 import mil.army.usace.hec.vortex.util.MatrixUtils;
+import mil.army.usace.hec.vortex.util.UnitUtil;
 import org.gdal.osr.SpatialReference;
 
 import javax.measure.Unit;
@@ -72,7 +73,7 @@ public class DssDataWriter extends DataWriter {
                 }
             }
 
-            Unit<?> units = getUnits(grid.units());
+            Unit<?> units = UnitUtil.getUnits(grid.units());
 
             DSSPathname dssPathname = new DSSPathname();
             String cPart = getCPartForGrid(grid.shortName());
@@ -454,67 +455,6 @@ public class DssDataWriter extends DataWriter {
         return pathnameOut;
     }
 
-    private static Unit<?> getUnits(String units){
-        switch (units.toLowerCase()){
-            case "kg.m-2.s-1":
-            case "kg m-2 s-1":
-            case "kg/m2s":
-            case "mm/s":
-                return MILLI(METRE).divide(SECOND);
-            case "mm hr^-1":
-            case "mm/hr":
-                return MILLI(METRE).divide(HOUR);
-            case "mm/day":
-            case "mm/d":
-                return MILLI(METRE).divide(DAY);
-            case "kg.m-2":
-            case "kg/m^2":
-            case "kg m^-2":
-            case "kg m-2":
-            case "mm":
-            case "millimeters h20":
-            case "millimeters snow thickness":
-                return MILLI(METRE);
-            case "in":
-            case "inch":
-            case "inches":
-                return INCH;
-            case "1/1000 in":
-                return ONE.divide(INCH.multiply(1000));
-            case "celsius":
-            case "degrees c":
-            case "deg c":
-            case "c":
-                return CELSIUS;
-            case "degc-d":
-                return CELSIUS.multiply(DAY);
-            case "fahrenheit":
-            case "degf":
-            case "deg f":
-            case "f":
-                return FAHRENHEIT;
-            case "kelvin":
-            case "k":
-                return KELVIN;
-            case "watt/m2":
-                return WATT.divide(SQUARE_METRE);
-            case "j m**-2":
-                return JOULE.divide(SQUARE_METRE);
-            case "kph":
-                return KILO(METRE).divide(HOUR);
-            case "%":
-                return PERCENT;
-            case "hpa":
-                return HECTO(PASCAL);
-            case "pa":
-                return PASCAL;
-            case "m":
-                return METRE;
-            default:
-                return ONE;
-        }
-    }
-
     private static String getUnitsString(Unit<?> unit){
         if (unit.equals(MILLI(METRE))){
             return "MM";
@@ -718,7 +658,7 @@ public class DssDataWriter extends DataWriter {
 
         gridInfo.setCellInfo(minX, minY, grid.nx(), grid.ny(), cellSize);
 
-        Unit<?> units = getUnits(grid.units());
+        Unit<?> units = UnitUtil.getUnits(grid.units());
         String unitsString = getUnitsString(units);
         gridInfo.setDataUnits(unitsString);
 

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/ImportableUnit.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/ImportableUnit.java
@@ -109,7 +109,7 @@ public class ImportableUnit {
             writer.write();
         });
 
-        support.firePropertyChange("complete", null, null);
+        support.firePropertyChange(DataWriter.WRITE_COMPLETED, null, null);
     }
 
     public void addPropertyChangeListener(PropertyChangeListener pcl) {

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/NetcdfDataWriter.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/NetcdfDataWriter.java
@@ -1,0 +1,85 @@
+package mil.army.usace.hec.vortex.io;
+
+import mil.army.usace.hec.vortex.VortexGrid;
+import ucar.nc2.Attribute;
+import ucar.nc2.write.Nc4Chunking;
+import ucar.nc2.write.Nc4ChunkingStrategy;
+import ucar.nc2.write.NetcdfFileFormat;
+import ucar.nc2.write.NetcdfFormatWriter;
+
+import java.beans.PropertyChangeListener;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class NetcdfDataWriter extends DataWriter {
+    private final List<VortexGrid> vortexGridList;
+    private final boolean isOverwrite;
+
+    // NetCDF4 Settings
+    public static final Nc4Chunking.Strategy CHUNKING_STRATEGY = Nc4Chunking.Strategy.standard;
+    public static final int DEFLATE_LEVEL = 9;
+    public static final boolean SHUFFLE = false;
+    public static final NetcdfFileFormat NETCDF_FORMAT = NetcdfFileFormat.NETCDF4;
+
+    /* Constructor */
+    NetcdfDataWriter(Builder builder) {
+        super(builder);
+        String overwriteOption = options.get("isOverwrite");
+        isOverwrite = overwriteOption == null || Boolean.parseBoolean(overwriteOption);
+        vortexGridList = data.stream()
+                .filter(VortexGrid.class::isInstance)
+                .map(VortexGrid.class::cast)
+                .collect(Collectors.toList());
+    }
+
+    /* Write */
+    @Override
+    public void write() {
+        if (isOverwrite) overwriteData();
+        else appendData();
+    }
+
+    private void overwriteData() {
+        NetcdfFormatWriter.Builder writerBuilder = initWriterBuilder(isOverwrite);
+        addGlobalAttributes(writerBuilder);
+
+        NetcdfGridWriter gridWriter = new NetcdfGridWriter(vortexGridList);
+        gridWriter.addListener(writerPropertyListener());
+        gridWriter.write(writerBuilder);
+    }
+
+    public void appendData() {
+        NetcdfFormatWriter.Builder writerBuilder = initWriterBuilder(isOverwrite);
+        NetcdfGridWriter gridWriter = new NetcdfGridWriter(vortexGridList);
+        gridWriter.addListener(writerPropertyListener());
+        gridWriter.appendData(writerBuilder);
+    }
+
+    private NetcdfFormatWriter.Builder initWriterBuilder(boolean isOverwrite) {
+        Nc4Chunking chunker = Nc4ChunkingStrategy.factory(CHUNKING_STRATEGY, DEFLATE_LEVEL, SHUFFLE);
+        return NetcdfFormatWriter.builder()
+                .setNewFile(isOverwrite)
+                .setFormat(NETCDF_FORMAT)
+                .setLocation(destination.toString())
+                .setChunker(chunker);
+    }
+
+    private PropertyChangeListener writerPropertyListener() {
+        return e -> {
+            String propertyName = e.getPropertyName();
+            if (propertyName.equals(DataWriter.WRITE_COMPLETED)) {
+                fireWriteCompleted();
+            }
+
+            if (propertyName.equals(DataWriter.WRITE_ERROR)) {
+                String errorMessage = String.valueOf(e.getNewValue());
+                fireWriteError(errorMessage);
+            }
+        };
+    }
+
+    /* Add Global Attributes */
+    private void addGlobalAttributes(NetcdfFormatWriter.Builder writerBuilder) {
+        writerBuilder.addAttribute(new Attribute("Conventions", "CF-1.10"));
+    }
+}

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/NetcdfGridWriter.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/NetcdfGridWriter.java
@@ -1,0 +1,342 @@
+package mil.army.usace.hec.vortex.io;
+
+import mil.army.usace.hec.vortex.VortexVariable;
+import mil.army.usace.hec.vortex.VortexGrid;
+import mil.army.usace.hec.vortex.VortexGridCollection;
+import mil.army.usace.hec.vortex.util.UnitUtil;
+import ucar.ma2.Array;
+import ucar.ma2.DataType;
+import ucar.ma2.InvalidRangeException;
+import ucar.nc2.Attribute;
+import ucar.nc2.Dimension;
+import ucar.nc2.Variable;
+import ucar.nc2.constants.CDM;
+import ucar.nc2.constants.CF;
+import ucar.nc2.write.NetcdfFormatWriter;
+import ucar.unidata.util.Parameter;
+
+import javax.measure.Unit;
+import java.beans.PropertyChangeListener;
+import java.beans.PropertyChangeSupport;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+import static javax.measure.MetricPrefix.*;
+import static systems.uom.common.USCustomary.*;
+import static tech.units.indriya.unit.Units.HOUR;
+import static tech.units.indriya.unit.Units.*;
+
+public class NetcdfGridWriter {
+    private static final Logger logger = Logger.getLogger(NetcdfGridWriter.class.getName());
+    private final PropertyChangeSupport support = new PropertyChangeSupport(this);
+    public static final int BOUNDS_LEN = 2;
+
+    private final Map<String, VortexGridCollection> gridCollectionMap;
+    private final VortexGridCollection defaultCollection;
+    // Dimensions
+    private final Dimension timeDim;
+    private final Dimension latDim;
+    private final Dimension lonDim;
+    private final Dimension yDim;
+    private final Dimension xDim;
+    private final Dimension boundsDim; // For all axis that has bounds (interval data)
+
+    public NetcdfGridWriter(List<VortexGrid> vortexGridList) {
+        gridCollectionMap = initGridCollectionMap(vortexGridList);
+        defaultCollection = getAnyCollection();
+        // Dimensions
+        timeDim = Dimension.builder().setName(CF.TIME).setIsUnlimited(true).build();
+        latDim = Dimension.builder().setName(CF.LATITUDE).setLength(defaultCollection.getNy()).build();
+        lonDim = Dimension.builder().setName(CF.LONGITUDE).setLength(defaultCollection.getNx()).build();
+        yDim = Dimension.builder().setName("y").setLength(defaultCollection.getNy()).build();
+        xDim = Dimension.builder().setName("x").setLength(defaultCollection.getNx()).build();
+        boundsDim = Dimension.builder().setName("nv").setLength(BOUNDS_LEN).build();
+    }
+
+    private Map<String, VortexGridCollection> initGridCollectionMap(List<VortexGrid> vortexGridList) {
+        Map<String, VortexGridCollection> map = vortexGridList.stream()
+                .collect(Collectors.groupingBy(
+                        VortexGrid::shortName,
+                        Collectors.collectingAndThen(Collectors.toList(), VortexGridCollection::new))
+                );
+        boolean isValidMap = verifyGridCollectionMap(map);
+        return isValidMap ? map : Collections.emptyMap();
+    }
+
+    private boolean verifyGridCollectionMap(Map<String, VortexGridCollection> map) {
+        boolean projectionMatched = isUnique(VortexGridCollection::getProjection, map);
+        // No need to check lat & lon since they are generated from (x & y & projection)
+        boolean yMatched = isUnique(VortexGridCollection::getYCoordinates, map);
+        boolean xMatched = isUnique(VortexGridCollection::getXCoordinates, map);
+        boolean timeMatched = isUnique(VortexGridCollection::getTimeData, map);
+        return projectionMatched && yMatched && xMatched && timeMatched;
+    }
+
+    private boolean isUnique(Function<VortexGridCollection, ?> propertyGetter, Map<String, VortexGridCollection> map) {
+        boolean isUnique = map.values().stream()
+                .map(propertyGetter)
+                .map(o -> (o instanceof double[] || o instanceof float[]) ? Arrays.deepToString(new Object[] {o}) : o)
+                .distinct()
+                .count() == 1;
+        if (!isUnique) logger.severe("Data is not the same for all grids");
+        return isUnique;
+    }
+
+    private VortexGridCollection getAnyCollection() {
+        return gridCollectionMap.values().stream().findAny().orElse(null);
+    }
+
+    /* Write Methods */
+    public void write(NetcdfFormatWriter.Builder writerBuilder) {
+        addDimensions(writerBuilder);
+        addVariables(writerBuilder);
+
+        try (NetcdfFormatWriter writer = writerBuilder.build()) {
+            writeDimensions(writer);
+            writeVariableGrids(writer, 0);
+        } catch (IOException | InvalidRangeException e) {
+            logger.severe(e.getMessage());
+        }
+    }
+
+    private void writeDimensions(NetcdfFormatWriter writer) throws InvalidRangeException, IOException {
+        writer.write(timeDim.getShortName(), Array.makeFromJavaArray(defaultCollection.getTimeData()));
+
+        if (defaultCollection.hasTimeBounds())
+            writer.write(getBoundsName(timeDim), Array.makeFromJavaArray(defaultCollection.getTimeBoundsArray()));
+
+        if (defaultCollection.isGeographic()) writeDimensionsGeographic(writer);
+        else writeDimensionsProjected(writer);
+    }
+
+    private void writeDimensionsGeographic(NetcdfFormatWriter writer) throws InvalidRangeException, IOException {
+        writer.write(latDim.getShortName(), Array.makeFromJavaArray(defaultCollection.getYCoordinates()));
+        writer.write(lonDim.getShortName(), Array.makeFromJavaArray(defaultCollection.getXCoordinates()));
+    }
+
+    private void writeDimensionsProjected(NetcdfFormatWriter writer) throws InvalidRangeException, IOException {
+        Map<String, double[][]> latLonMap = defaultCollection.getLatLonCoordinates();
+        writer.write(yDim.getShortName(), Array.makeFromJavaArray(defaultCollection.getYCoordinates()));
+        writer.write(xDim.getShortName(), Array.makeFromJavaArray(defaultCollection.getXCoordinates()));
+        writer.write(latDim.getShortName(), Array.makeFromJavaArray(latLonMap.get("lat")));
+        writer.write(lonDim.getShortName(), Array.makeFromJavaArray(latLonMap.get("lon")));
+    }
+
+    private void writeVariableGrids(NetcdfFormatWriter writer, int startIndex) {
+        AtomicBoolean hasErrors = new AtomicBoolean(false);
+
+        for (VortexGridCollection collection : gridCollectionMap.values()) {
+            VortexVariable meteorologicalVariable = getVortexVariable(collection);
+            Variable variable = writer.findVariable(meteorologicalVariable.getShortName());
+            if (variable == null) {
+                logger.severe("Failed to locate variable: " + meteorologicalVariable.getShortName());
+                hasErrors.set(true);
+                continue;
+            }
+
+            collection.getCollectionDataStream().forEach(entry -> {
+                try {
+                    int index = entry.getKey() + startIndex;
+                    VortexGrid grid = entry.getValue();
+                    int[] origin = {index, 0, 0};
+                    writer.write(variable, origin, Array.makeFromJavaArray(grid.data3D()));
+                    support.firePropertyChange(DataWriter.WRITE_COMPLETED, null, null);
+                } catch (IOException | InvalidRangeException e) {
+                    logger.warning(e.getMessage());
+                    hasErrors.set(true);
+                }
+            });
+        }
+
+        if (hasErrors.get()) {
+            boolean isAppend = startIndex > 0;
+            String overwriteErrorMessage = "Failed to overwrite file.";
+            String appendErrorMessage = "Some reasons may be:\n* Attempted to append to non-existing variable\n* Attempted to append data with different projection\n* Attempted to append data with different location";
+            String message = isAppend ? appendErrorMessage : overwriteErrorMessage;
+            support.firePropertyChange(DataWriter.WRITE_ERROR, null, message);
+        }
+    }
+
+    /* Add Dimensions */
+    private void addDimensions(NetcdfFormatWriter.Builder writerBuilder) {
+        writerBuilder.addDimension(timeDim);
+        if (defaultCollection.hasTimeBounds()) writerBuilder.addDimension(boundsDim);
+
+        if (defaultCollection.isGeographic()) {
+            writerBuilder.addDimension(latDim);
+            writerBuilder.addDimension(lonDim);
+        } else {
+            writerBuilder.addDimension(yDim);
+            writerBuilder.addDimension(xDim);
+        }
+    }
+
+    /* Add Variables */
+    private void addVariables(NetcdfFormatWriter.Builder writerBuilder) {
+        addVariableTime(writerBuilder);
+        if (defaultCollection.hasTimeBounds()) addVariableTimeBounds(writerBuilder);
+        addVariableLat(writerBuilder);
+        addVariableLon(writerBuilder);
+        addVariableGridCollection(writerBuilder);
+
+        if (!defaultCollection.isGeographic()) {
+            addVariableProjection(writerBuilder);
+            addVariableX(writerBuilder);
+            addVariableY(writerBuilder);
+        }
+    }
+
+    private void addVariableTime(NetcdfFormatWriter.Builder writerBuilder) {
+        Variable.Builder<?> v = writerBuilder.addVariable(timeDim.getShortName(), DataType.FLOAT, List.of(timeDim));
+        v.addAttribute(new Attribute(CF.STANDARD_NAME, CF.TIME));
+        v.addAttribute(new Attribute(CF.CALENDAR, "standard"));
+        v.addAttribute(new Attribute(CF.UNITS, defaultCollection.getTimeUnits()));
+        if (defaultCollection.hasTimeBounds()) v.addAttribute(new Attribute(CF.BOUNDS, getBoundsName(timeDim)));
+    }
+
+    private void addVariableTimeBounds(NetcdfFormatWriter.Builder writerBuilder) {
+        writerBuilder.addVariable(getBoundsName(timeDim), DataType.FLOAT, List.of(timeDim, boundsDim));
+    }
+
+    private void addVariableLat(NetcdfFormatWriter.Builder writerBuilder) {
+        boolean isGeographic = defaultCollection.isGeographic();
+        List<Dimension> dimensions = isGeographic ? List.of(latDim) : List.of(yDim, xDim);
+        writerBuilder.addVariable(latDim.getShortName(), DataType.DOUBLE, dimensions)
+                .addAttribute(new Attribute(CF.UNITS, CDM.LAT_UNITS))
+                .addAttribute(new Attribute(CF.LONG_NAME, "latitude coordinate"))
+                .addAttribute(new Attribute(CF.STANDARD_NAME, CF.LATITUDE));
+    }
+
+    private void addVariableLon(NetcdfFormatWriter.Builder writerBuilder) {
+        boolean isGeographic = defaultCollection.isGeographic();
+        List<Dimension> dimensions = isGeographic ? List.of(lonDim) : List.of(yDim, xDim);
+        writerBuilder.addVariable(lonDim.getShortName(), DataType.DOUBLE, dimensions)
+                .addAttribute(new Attribute(CF.UNITS, CDM.LON_UNITS))
+                .addAttribute(new Attribute(CF.LONG_NAME, "longitude coordinate"))
+                .addAttribute(new Attribute(CF.STANDARD_NAME, CF.LONGITUDE));
+    }
+
+    private void addVariableY(NetcdfFormatWriter.Builder writerBuilder) {
+        writerBuilder.addVariable(yDim.getShortName(), DataType.DOUBLE, List.of(yDim))
+                .addAttribute(new Attribute(CF.UNITS, defaultCollection.getProjectionUnit()))
+                .addAttribute(new Attribute(CF.STANDARD_NAME, CF.PROJECTION_Y_COORDINATE));
+    }
+
+    private void addVariableX(NetcdfFormatWriter.Builder writerBuilder) {
+        writerBuilder.addVariable(xDim.getShortName(), DataType.DOUBLE, List.of(xDim))
+                .addAttribute(new Attribute(CF.UNITS, defaultCollection.getProjectionUnit()))
+                .addAttribute(new Attribute(CF.STANDARD_NAME, CF.PROJECTION_X_COORDINATE));
+    }
+
+    private void addVariableProjection(NetcdfFormatWriter.Builder writerBuilder) {
+        Variable.Builder<?> variableBuilder = writerBuilder.addVariable(defaultCollection.getProjectionName(), DataType.SHORT, Collections.emptyList());
+        for (Parameter parameter : defaultCollection.getProjection().getProjectionParameters()) {
+            String name = parameter.getName();
+            String stringValue = parameter.getStringValue();
+            double[] numericValues = parameter.getNumericValues();
+
+            if (stringValue == null && numericValues == null) {
+                String logMessage = String.format("Parameter '%s' has no value", parameter.getName());
+                logger.severe(logMessage);
+                continue;
+            }
+
+            Attribute attribute = (stringValue != null) ?
+                    Attribute.builder().setName(name).setStringValue(stringValue).build() :
+                    Attribute.builder().setName(name).setValues(Array.makeFromJavaArray(numericValues)).build();
+            variableBuilder.addAttribute(attribute);
+        }
+    }
+
+    private void addVariableGridCollection(NetcdfFormatWriter.Builder writerBuilder) {
+        boolean isGeographic = defaultCollection.isGeographic();
+        List<Dimension> dimensions = isGeographic ? List.of(timeDim, latDim, lonDim) : List.of(timeDim, yDim, xDim);
+        for (VortexGridCollection collection : gridCollectionMap.values()) {
+            VortexVariable variable = getVortexVariable(collection);
+            Unit<?> dataUnit = UnitUtil.getUnits(collection.getDataUnit());
+            writerBuilder.addVariable(variable.getShortName(), DataType.FLOAT, dimensions)
+                    .addAttribute(new Attribute(CF.LONG_NAME, variable.getLongName()))
+                    .addAttribute(new Attribute(CF.UNITS, getUnitsString(dataUnit)))
+                    .addAttribute(new Attribute(CF.GRID_MAPPING, defaultCollection.getProjectionName()))
+                    .addAttribute(new Attribute(CF.COORDINATES, "latitude longitude"))
+                    .addAttribute(new Attribute(CF.MISSING_VALUE, collection.getNoDataValue()))
+                    .addAttribute(new Attribute(CF._FILLVALUE, collection.getNoDataValue()))
+                    .addAttribute(new Attribute(CF.CELL_METHODS, collection.getDataType().getNcString()));
+        }
+    }
+
+    /* Helpers */
+    private String getBoundsName(Dimension dimension) {
+        return dimension.getShortName() + "_bnds";
+    }
+
+    private static VortexVariable getVortexVariable(VortexGridCollection collection) {
+        VortexVariable name = VortexVariable.fromName(collection.getShortName());
+        return name.equals(VortexVariable.UNDEFINED) ? VortexVariable.fromName(collection.getDescription()) : name;
+    }
+
+    private static String getUnitsString(Unit<?> unit){
+        if (unit.equals(MILLI(METRE).divide(SECOND))) return "mm/s";
+        if (unit.equals(MILLI(METRE).divide(HOUR))) return "mm/hr";
+        if (unit.equals(MILLI(METRE).divide(DAY))) return "mm/day";
+        if (unit.equals(MILLI(METRE))) return "mm";
+        if (unit.equals(INCH)) return "in";
+        if (unit.equals(CELSIUS)) return "degC";
+        if (unit.equals(CELSIUS.multiply(DAY))) return "degC-d";
+        if (unit.equals(FAHRENHEIT)) return "degF";
+        if (unit.equals(KELVIN)) return "K";
+        if (unit.equals(WATT.divide(SQUARE_METRE))) return "W m-2";
+        if (unit.equals(JOULE.divide(SQUARE_METRE))) return "J m-2";
+        if (unit.equals(KILO(METRE).divide(HOUR))) return "kph";
+        if (unit.equals(KILOMETRE_PER_HOUR)) return "km h-1";
+        if (unit.equals(PERCENT)) return "%";
+        if (unit.equals(HECTO(PASCAL))) return "hPa";
+        if (unit.equals(PASCAL)) return "Pa";
+        if (unit.equals(METRE)) return "m";
+        if (unit.equals(CUBIC_METRE.divide(SECOND))) return "m3 s-1";
+        if (unit.equals(CUBIC_FOOT.divide(SECOND))) return "cfs";
+        if (unit.equals(FOOT)) return "ft";
+        if (unit.equals(METRE_PER_SECOND)) return "m/s";
+        if (unit.equals(MILE_PER_HOUR)) return "mph";
+        if (unit.equals(FOOT_PER_SECOND)) return "ft/s";
+        if (unit.equals(KILO(PASCAL))) return "kPa";
+        if (unit.equals(KILO(METRE))) return "km";
+        if (unit.equals(MILE)) return "mi";
+        if (unit.equals(TON)) return "ton";
+        if (unit.equals(MILLI(GRAM).divide(LITRE))) return "mg L-1";
+        return "Unspecified";
+    }
+
+    /* Property Change */
+    public void addListener(PropertyChangeListener pcl) {
+        this.support.addPropertyChangeListener(pcl);
+    }
+
+    public void removeListener(PropertyChangeListener pcl) {
+        this.support.removePropertyChangeListener(pcl);
+    }
+
+    /* Append Data */
+    public void appendData(NetcdfFormatWriter.Builder writerBuilder) {
+        try (NetcdfFormatWriter writer = writerBuilder.build()) {
+            Variable timeVar = writer.findVariable(CF.TIME);
+            if (timeVar == null) {
+                logger.severe("Time variable not found");
+                return;
+            }
+
+            int startIndex = timeVar.getShape(0);
+            writeVariableGrids(writer, startIndex);
+            writer.write(timeVar, new int[] {startIndex}, Array.makeFromJavaArray(defaultCollection.getTimeData()));
+        } catch (IOException | InvalidRangeException e) {
+            logger.severe(e.getMessage());
+        }
+    }
+}

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/SerialBatchImporter.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/SerialBatchImporter.java
@@ -1,0 +1,49 @@
+package mil.army.usace.hec.vortex.io;
+
+import mil.army.usace.hec.vortex.VortexData;
+import mil.army.usace.hec.vortex.VortexGrid;
+import mil.army.usace.hec.vortex.geo.GeographicProcessor;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.List;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+class SerialBatchImporter extends BatchImporter {
+    private static final Logger logger = Logger.getLogger(SerialBatchImporter.class.getName());
+
+    SerialBatchImporter(Builder builder) {
+        super(builder);
+    }
+
+    @Override
+    public void process() {
+        Instant start = Instant.now();
+
+        GeographicProcessor geoProcessor = new GeographicProcessor(geoOptions);
+
+        List<VortexData> vortexDataList = getDataReaders().parallelStream()
+                .map(DataReader::getDtos)
+                .flatMap(Collection::stream)
+                .filter(VortexGrid.class::isInstance)
+                .map(VortexGrid.class::cast)
+                .map(geoProcessor::process)
+                .collect(Collectors.toList());
+
+        DataWriter writer = DataWriter.builder()
+                .data(vortexDataList)
+                .destination(destination)
+                .options(writeOptions)
+                .build();
+
+        int totalCount = vortexDataList.size();
+        writer.addListener(writeProgressListener(totalCount));
+        writer.write();
+
+        long seconds = Duration.between(start, Instant.now()).toSeconds();
+        String timeMessage = String.format("Batch import time: %d:%02d:%02d%n", seconds / 3600, (seconds % 3600) / 60, (seconds % 60));
+        logger.info(timeMessage);
+    }
+}

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/util/TimeConverter.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/util/TimeConverter.java
@@ -1,6 +1,7 @@
 package mil.army.usace.hec.vortex.util;
 
 import hec.heclib.util.HecTime;
+import ucar.nc2.time.CalendarDate;
 
 import java.time.ZonedDateTime;
 import java.util.Date;
@@ -11,6 +12,10 @@ public class TimeConverter {
 
     public static ZonedDateTime toZonedDateTime(HecTime hecTime){
         return ZonedDateTime.parse(hecTime.getXMLDateTime(0));
+    }
+
+    public static ZonedDateTime toZonedDateTime(CalendarDate calendarDate){
+        return ZonedDateTime.parse(calendarDate.toString());
     }
 
     public static HecTime toHecTime(ZonedDateTime zonedDateTime){

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/util/UnitUtil.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/util/UnitUtil.java
@@ -1,0 +1,74 @@
+package mil.army.usace.hec.vortex.util;
+
+import javax.measure.Unit;
+
+import static javax.measure.MetricPrefix.*;
+import static systems.uom.common.USCustomary.*;
+import static tech.units.indriya.AbstractUnit.ONE;
+import static tech.units.indriya.unit.Units.*;
+import static tech.units.indriya.unit.Units.DAY;
+import static tech.units.indriya.unit.Units.HOUR;
+
+public class UnitUtil {
+    public static Unit<?> getUnits(String units) {
+        switch (units.toLowerCase()) {
+            case "kg.m-2.s-1":
+            case "kg m-2 s-1":
+            case "kg/m2s":
+            case "mm/s":
+                return MILLI(METRE).divide(SECOND);
+            case "mm hr^-1":
+            case "mm/hr":
+                return MILLI(METRE).divide(HOUR);
+            case "mm/day":
+            case "mm/d":
+                return MILLI(METRE).divide(DAY);
+            case "kg.m-2":
+            case "kg/m^2":
+            case "kg m^-2":
+            case "kg m-2":
+            case "mm":
+            case "millimeters h20":
+            case "millimeters snow thickness":
+                return MILLI(METRE);
+            case "in":
+            case "inch":
+            case "inches":
+                return INCH;
+            case "1/1000 in":
+                return ONE.divide(INCH.multiply(1000));
+            case "celsius":
+            case "degrees c":
+            case "deg c":
+            case "degc":
+            case "c":
+                return CELSIUS;
+            case "degc-d":
+                return CELSIUS.multiply(DAY);
+            case "fahrenheit":
+            case "degf":
+            case "deg f":
+            case "f":
+                return FAHRENHEIT;
+            case "kelvin":
+            case "k":
+                return KELVIN;
+            case "watt/m2":
+                return WATT.divide(SQUARE_METRE);
+            case "j m**-2":
+                return JOULE.divide(SQUARE_METRE);
+            case "kph":
+                return KILO(METRE).divide(HOUR);
+            case "%":
+                return PERCENT;
+            case "hpa":
+                return HECTO(PASCAL);
+            case "pa":
+                return PASCAL;
+            case "m":
+                return METRE;
+            default:
+                return ONE;
+        }
+    }
+}

--- a/vortex-api/src/test/java/mil/army/usace/hec/vortex/TestUtil.java
+++ b/vortex-api/src/test/java/mil/army/usace/hec/vortex/TestUtil.java
@@ -1,11 +1,29 @@
 package mil.army.usace.hec.vortex;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.URL;
+import java.nio.file.Files;
+import java.util.logging.Logger;
 
 public class TestUtil {
+    private static final Logger logger = Logger.getLogger(TestUtil.class.getName());
+
     public static File getResourceFile(String pathFromResource) {
         URL url = TestUtil.class.getResource(pathFromResource);
         return (url != null) ? new File(url.getFile()) : null;
+    }
+
+    public static String createTempFile(String fileName) {
+        try {
+            int index = fileName.lastIndexOf(".");
+            boolean hasExtension = index > 0;
+            String prefix = hasExtension ? fileName.substring(0, index) : fileName;
+            String suffix = hasExtension ? fileName.substring(index) : "";
+            return Files.createTempFile(prefix, suffix).toAbsolutePath().toString();
+        } catch (IOException e) {
+            logger.warning(e.getMessage());
+            return null;
+        }
     }
 }

--- a/vortex-api/src/test/java/mil/army/usace/hec/vortex/io/NetcdfDataWriterTest.java
+++ b/vortex-api/src/test/java/mil/army/usace/hec/vortex/io/NetcdfDataWriterTest.java
@@ -1,0 +1,127 @@
+package mil.army.usace.hec.vortex.io;
+
+import mil.army.usace.hec.vortex.TestUtil;
+import mil.army.usace.hec.vortex.VortexData;
+import mil.army.usace.hec.vortex.VortexDataType;
+import mil.army.usace.hec.vortex.VortexGrid;
+import mil.army.usace.hec.vortex.geo.WktFactory;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import ucar.unidata.geoloc.projection.proj4.LambertConformalConicEllipse;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+class NetcdfDataWriterTest {
+    @Test
+    void InstantTimeCircleTest() throws IOException {
+        ZonedDateTime time = ZonedDateTime.of(1900,2,2,0,0,0,0, ZoneId.of("Z"));
+        List<VortexData> originalGrids = new ArrayList<>();
+
+        for (int i = 0; i < 5; i++) {
+            float[] data = new float[9];
+            Arrays.fill(data, i);
+
+            VortexGrid grid = VortexGrid.builder()
+                    .originX(0).originY(0)
+                    .nx(3).ny(3)
+                    .dx(1).dy(1)
+                    .wkt(WktFactory.createWkt(new LambertConformalConicEllipse()))
+                    .data(data)
+                    .noDataValue(-9999)
+                    .units("degC")
+                    .shortName("temperature")
+                    .description("air_temperature")
+                    .startTime(time.plusHours(i))
+                    .endTime(time.plusHours(i))
+                    .interval(Duration.between(time, time))
+                    .dataType(VortexDataType.INSTANTANEOUS)
+                    .build();
+
+            originalGrids.add(grid);
+        }
+
+        String outputPath = TestUtil.createTempFile("InstantTimeCircleTest.nc");
+        Assertions.assertNotNull(outputPath);
+
+        DataWriter writer = DataWriter.builder()
+                .data(originalGrids)
+                .destination(outputPath)
+                .build();
+
+        writer.write();
+
+        DataReader reader = DataReader.builder()
+                .variable("temperature")
+                .path(outputPath)
+                .build();
+
+        List<VortexData> generatedGrids = reader.getDtos();
+
+        for (int i = 0; i < originalGrids.size(); i++) {
+            Assertions.assertEquals(originalGrids.get(i), generatedGrids.get(i));
+        }
+
+        Files.deleteIfExists(Path.of(outputPath));
+    }
+
+    @Test
+    void IntervalTimeCircleTest() throws IOException {
+        ZonedDateTime startTime = ZonedDateTime.of(1900,2,2,0,0,0,0, ZoneId.of("Z"));
+        ZonedDateTime endTime = startTime.plusHours(1);
+        List<VortexData> originalGrids = new ArrayList<>();
+
+        for (int i = 0; i < 5; i++) {
+            float[] data = new float[9];
+            Arrays.fill(data, i);
+
+            VortexGrid grid = VortexGrid.builder()
+                    .originX(0).originY(0)
+                    .nx(3).ny(3)
+                    .dx(1).dy(1)
+                    .wkt(WktFactory.createWkt(new LambertConformalConicEllipse()))
+                    .data(data)
+                    .noDataValue(-9999)
+                    .units("m")
+                    .shortName("precipitation")
+                    .description("lwe_thickness_of_precipitation_amount")
+                    .startTime(startTime.plusHours(i))
+                    .endTime(endTime.plusHours(i))
+                    .interval(Duration.between(startTime, endTime))
+                    .dataType(VortexDataType.UNDEFINED)
+                    .build();
+
+            originalGrids.add(grid);
+        }
+
+        String outputPath = TestUtil.createTempFile("IntervalTimeCircleTest.nc");
+        Assertions.assertNotNull(outputPath);
+
+        DataWriter writer = DataWriter.builder()
+                .data(originalGrids)
+                .destination(outputPath)
+                .build();
+
+        writer.write();
+
+        DataReader reader = DataReader.builder()
+                .variable("precipitation")
+                .path(outputPath)
+                .build();
+
+        List<VortexData> generatedGrids = reader.getDtos();
+
+        for (int i = 0; i < originalGrids.size(); i++) {
+            Assertions.assertEquals(originalGrids.get(i), generatedGrids.get(i));
+        }
+
+        Files.deleteIfExists(Path.of(outputPath));
+    }
+}

--- a/vortex-ui/build.gradle.kts
+++ b/vortex-ui/build.gradle.kts
@@ -14,6 +14,7 @@ repositories {
 dependencies {
     implementation(project(":vortex-api"))
     implementation("org.gdal:gdal:3.2.0")
+    implementation("com.formdev:flatlaf:3.1.1")
     testImplementation("org.junit.jupiter:junit-jupiter:5.4.2")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.4.2")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.4.2")
@@ -51,28 +52,30 @@ fun uiJvmArgs(): List<String> {
 }
 
 fun uiEnvironment(): Map<String,String> {
-    if(isWindows()) {
+    if (isWindows()) {
         return mapOf(
-                "PATH" to "${rootProject.projectDir}/bin/gdal",
-                "GDAL_DRIVER_PATH" to "${rootProject.projectDir}/bin/gdal/gdalplugins",
-                "GDAL_DATA" to "${rootProject.projectDir}/bin/gdal/gdal-data",
-                "PROJ_LIB" to "${rootProject.projectDir}/bin/gdal/projlib"
+            "PATH" to "${rootProject.projectDir}/bin/gdal",
+            "GDAL_DRIVER_PATH" to "${rootProject.projectDir}/bin/gdal/gdalplugins",
+            "GDAL_DATA" to "${rootProject.projectDir}/bin/gdal/gdal-data",
+            "PROJ_LIB" to "${rootProject.projectDir}/bin/gdal/projlib"
         )
     }
 
-    if(isMacOsX()) {
+    if (isMacOsX()) {
         return mapOf(
-                "DYLD_FALLBACK_LIBRARY_PATH" to "@loader_path",
-                "PROJ_LIB" to "${rootProject.projectDir}/bin/gdal"
+            "DYLD_LIBRARY_PATH" to "${rootProject.projectDir}/bin/gdal",
+            "DYLD_FALLBACK_LIBRARY_PATH" to "@loader_path",
+            "GDAL_DATA" to "${rootProject.projectDir}/bin/gdal-data",
+            "PROJ_LIB" to "${rootProject.projectDir}/bin/proj-db"
         )
     }
 
-    if(isLinux()) {
+    if (isLinux()) {
         return mapOf(
-                "PATH" to "${rootProject.projectDir}/bin/gdal",
-                "GDAL_DRIVER_PATH" to "${rootProject.projectDir}/bin/gdal/gdalplugins",
-                "GDAL_DATA" to "${rootProject.projectDir}/bin/gdal/gdal-data",
-                "PROJ_LIB" to "${rootProject.projectDir}/bin/gdal/projlib"
+            "PATH" to "${rootProject.projectDir}/bin/gdal",
+            "GDAL_DRIVER_PATH" to "${rootProject.projectDir}/bin/gdal/gdalplugins",
+            "GDAL_DATA" to "${rootProject.projectDir}/bin/gdal/gdal-data",
+            "PROJ_LIB" to "${rootProject.projectDir}/bin/gdal/projlib"
         )
     }
 

--- a/vortex-ui/src/main/java/mil/army/usace/hec/vortex/ui/DestinationSelectionPanel.java
+++ b/vortex-ui/src/main/java/mil/army/usace/hec/vortex/ui/DestinationSelectionPanel.java
@@ -13,9 +13,14 @@ import java.util.Arrays;
 public class DestinationSelectionPanel extends JPanel {
     private final JFrame parent;
     private final JPanel dssPartsSelectionPanel;
+    private final JPanel netcdfOverwriteSelectionPanel;
+
     private JTextField selectDestinationTextField;
     private JTextField unitsTextField;
     private JComboBox<String> dataTypeCombo;
+
+    private JRadioButton netcdfOverwriteButton;
+    private JRadioButton netcdfAppendButton;
 
     @SuppressWarnings("unused")
     private JTextField dssFieldA, dssFieldB, dssFieldC, dssFieldD, dssFieldE, dssFieldF;
@@ -47,6 +52,13 @@ public class DestinationSelectionPanel extends JPanel {
         dssPartsSelectionPanel = dssPartsSelectionPanel();
         dssPartsSelectionPanel.setVisible(false);
         this.add(dssPartsSelectionPanel, gridBagConstraints);
+
+        /* NetCDF Overwrite Panel (Only appears when the selected destination is a NetCDF file */
+        gridBagConstraints.gridy = 1;
+        gridBagConstraints.insets = new Insets(15,0,0,0);
+        netcdfOverwriteSelectionPanel = initNetcdfOverwritePanel();
+        netcdfOverwriteSelectionPanel.setVisible(false);
+        this.add(netcdfOverwriteSelectionPanel, gridBagConstraints);
     }
 
     private JPanel dssFileSelectionPanel() {
@@ -66,7 +78,10 @@ public class DestinationSelectionPanel extends JPanel {
             public void changedUpdate(DocumentEvent e) { textUpdated(); }
             public void removeUpdate(DocumentEvent e) { textUpdated(); }
             public void insertUpdate(DocumentEvent e) { textUpdated(); }
-            void textUpdated() { dssPartsSelectionPanel.setVisible(selectDestinationTextField.getText().endsWith(".dss")); }
+            void textUpdated() {
+                dssPartsSelectionPanel.setVisible(selectDestinationTextField.getText().endsWith(".dss"));
+                netcdfOverwriteSelectionPanel.setVisible(selectDestinationTextField.getText().endsWith(".nc"));
+            }
         });
         selectDestinationTextFieldPanel.add(selectDestinationTextField);
 
@@ -177,6 +192,35 @@ public class DestinationSelectionPanel extends JPanel {
         return dssPartsPanel;
     }
 
+    private JPanel initNetcdfOverwritePanel() {
+        JPanel panel = new JPanel();
+        initNetcdfOverwriteRadio();
+        panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
+        panel.add(netcdfOverwriteButton);
+        panel.add(netcdfAppendButton);
+        String title = TextProperties.getInstance().getProperty("DestinationPanel_NetcdfWriteOption_Title");
+        panel.setBorder(BorderFactory.createTitledBorder(title));
+        return panel;
+    }
+
+    private void initNetcdfOverwriteRadio() {
+        ButtonGroup buttonGroup = new ButtonGroup();
+
+        String overwriteLabel = TextProperties.getInstance().getProperty("DestinationPanel_NetcdfOverwrite_L");
+        String overwriteTooltip = TextProperties.getInstance().getProperty("DestinationPanel_NetcdfOverwrite_TT");
+        netcdfOverwriteButton = new JRadioButton(overwriteLabel);
+        netcdfOverwriteButton.setToolTipText(overwriteTooltip);
+        netcdfOverwriteButton.setSelected(true);
+
+        String appendLabel = TextProperties.getInstance().getProperty("DestinationPanel_NetcdfAppend_L");
+        String appendTooltip = TextProperties.getInstance().getProperty("DestinationPanel_NetcdfAppend_TT");
+        netcdfAppendButton = new JRadioButton(appendLabel);
+        netcdfAppendButton.setToolTipText(appendTooltip);
+
+        buttonGroup.add(netcdfOverwriteButton);
+        buttonGroup.add(netcdfAppendButton);
+    }
+
     private JPanel overridePanel() {
         JPanel overridePanel = new JPanel(new GridBagLayout());
 
@@ -237,9 +281,11 @@ public class DestinationSelectionPanel extends JPanel {
         JFileChooser fileChooser = new JFileChooser(fileBrowseButton.getPersistedBrowseLocation());
 
         // Configuring fileChooser dialog
-        fileChooser.setAcceptAllFileFilterUsed(true);
-        FileNameExtensionFilter acceptableExtension = new FileNameExtensionFilter("DSS Files (*.dss)", "dss");
-        fileChooser.setFileFilter(acceptableExtension);
+        fileChooser.setAcceptAllFileFilterUsed(false);
+        FileNameExtensionFilter dssFilter = new FileNameExtensionFilter("DSS Files (*.dss)", "dss");
+        FileNameExtensionFilter ncFilter = new FileNameExtensionFilter("NetCDF Files (*.nc, *.nc3, *.nc4)", "nc", "nc3", "nc4");
+        fileChooser.addChoosableFileFilter(dssFilter);
+        fileChooser.addChoosableFileFilter(ncFilter);
 
         // Pop up fileChooser dialog
         int userChoice = fileChooser.showOpenDialog(parent);
@@ -295,5 +341,9 @@ public class DestinationSelectionPanel extends JPanel {
     public String getDataType() {
         Object dataType = dataTypeCombo.getSelectedItem();
         return (dataType != null) ? dataType.toString() : "";
+    }
+
+    public boolean isOverwrite() {
+        return netcdfOverwriteButton.isSelected();
     }
 }

--- a/vortex-ui/src/main/resources/text.properties
+++ b/vortex-ui/src/main/resources/text.properties
@@ -81,7 +81,8 @@ ImportMetWizCloseTT=Close Met Data Import
 ImportMetWizRestart=Restart
 ImportMetWizRestartTT=Restart Met Data Import
 ImportMetWizProcessing_L=Processing...
-ImportMetWizComplete_L=Import complete.
+ImportMetWizComplete_L=Import successfully completed.
+ImportMetWizFailed_L=Import failed to complete.
 #
 # Normalizer Wizard
 #
@@ -122,6 +123,14 @@ NormalizerWiz_PartE_L=Part E:
 NormalizerWiz_PartF_L=Part F:
 NormalizerWiz_Processing_L=Processing...
 NormalizerWiz_Complete_L=Normalizer complete.
+#
+# Destination Selection Panel
+#
+DestinationPanel_NetcdfWriteOption_Title=Write Option
+DestinationPanel_NetcdfOverwrite_L=Overwrite
+DestinationPanel_NetcdfOverwrite_TT=Overwrite
+DestinationPanel_NetcdfAppend_L=Append
+DestinationPanel_NetcdfAppend_TT=Append
 #
 # Sanitizer Wizard
 #
@@ -181,4 +190,8 @@ FileSavedDialogWarning_NoFile=File does not exist
 #
 FileOverrideDialogTitle=Confirm Override
 FileOverrideDialogMessage=already exists. Do you want to override it?
-
+#
+# NetcdfGridWriter
+#
+NetcdfGridWriter_OverwriteFailed=Failed to overwrite file.
+NetcdfGridWriter_AppendFailed=Some reasons may be:\n* Attempted to append to non-existing variable\n* Attempted to append data with different projection\n* Attempted to append data with different location


### PR DESCRIPTION
Added NetcdfGridWriter to write a List<VortexGrid> to a netcdf4 file, with v1.10 CF conventions. Added WktParser to parse wkt to Projection. Updated ReferenceUtils to delete SpatialReferences after use. Updated ReSampler to use the dataset's projection if no projection has been specified. Broken down BatchImporter to Concurrent/SerialBatchImporter. Updated DataWriter to support '.nc' as write destination. Added VortexVariable as a storage for common variable names. Added VortexDataType to distinguish between instant/interval/cumulative data. Moved 'getUnits' to UnitUtil. Added VortexGrid equals and hashCode. Added VortexGridCollection to store vortex grids and return necessary data to write to netcdf. Added TestUtil::createTempFile. Updated DestinationSelectionPanel to support write to netcdf format, and added 'Overwrite' and 'Append' option when destination is 'nc'. Added FlatLAF. Updated ImportMetWizard UI to accommodate '.nc' destination. Added Windows' Netcdf (4.9.2) artifact. Updated getNatives logic for macOS. Added netcdf and TEMP to Windows bat scripts. Updated netcdf4 java dependencies to 5.5.3, and specify new jna version (runtime only). Updated 'test' gradle configuration for Windows.

Resolves: HMS-2553