### PR TITLE
Add BufferedDataReader & TemporalDataReader

### DIFF
--- a/vortex-api/build.gradle.kts
+++ b/vortex-api/build.gradle.kts
@@ -11,12 +11,6 @@ repositories {
 }
 
 dependencies {
-    implementation("edu.ucar:netcdf4")
-    constraints {
-        implementation("edu.ucar:netcdf4:5.5.3")
-        runtimeOnly("net.java.dev.jna:jna:5.13.0")
-    }
-    
     implementation("mil.army.usace.hec:hec-monolith:3.+") {
         isTransitive = false
     }
@@ -34,6 +28,7 @@ dependencies {
     implementation("tech.units:indriya:2.1.4")
     implementation("systems.uom:systems-common:2.1")
     implementation("edu.ucar:cdm-core:5.5.3")
+    implementation("edu.ucar:netcdf4:5.5.3")
     implementation("org.apache.commons:commons-compress:1.21")
     implementation("org.hdfgroup:jarhdf5:3.3.2")
     //start runtime-only deps required by HEC shared libraries
@@ -47,6 +42,13 @@ dependencies {
     testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.4.2")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.9.2")
     testRuntimeOnly("org.junit.vintage:junit-vintage-engine:5.9.2")
+}
+
+configurations.all {
+    resolutionStrategy {
+        force("com.google.guava:guava:32.0.1-jre")
+        force("net.java.dev.jna:jna:5.13.0")
+    }
 }
 
 project.version = project.version.toString()

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/VortexGrid.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/VortexGrid.java
@@ -78,6 +78,31 @@ public class VortexGrid implements VortexData, Serializable {
         private Duration interval;
         private VortexDataType dataType;
 
+        public VortexGridBuilder() {
+            // Empty constructor
+        }
+
+        public VortexGridBuilder(VortexGrid copy) {
+            dx = copy.dx;
+            dy = copy.dy;
+            nx = copy.nx;
+            ny = copy.ny;
+            originX = copy.originX;
+            originY = copy.originY;
+            wkt = copy.wkt;
+            data = copy.data;
+            noDataValue = copy.noDataValue;
+            units = copy.units;
+            fileName = copy.fileName;
+            shortName = copy.shortName;
+            fullName = copy.fullName;
+            description = copy.description;
+            startTime = copy.startTime;
+            endTime = copy.endTime;
+            interval = copy.interval;
+            dataType = copy.dataType;
+        }
+
         public VortexGridBuilder dx (final double dx) {
             this.dx = dx;
             return this;
@@ -188,6 +213,10 @@ public class VortexGrid implements VortexData, Serializable {
         return new VortexGridBuilder();
     }
 
+    public VortexGridBuilder toBuilder() {
+        return new VortexGridBuilder(this);
+    }
+
     public double dx() {
         return dx;
     }
@@ -296,13 +325,14 @@ public class VortexGrid implements VortexData, Serializable {
         return data3D;
     }
 
+    public boolean isNoDataValue(double value) {
+        return value == noDataValue;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof VortexGrid)) return false;
-
-        VortexGrid that = (VortexGrid) o;
-
+        if (!(o instanceof VortexGrid that)) return false;
         if (Double.compare(that.dx, dx) != 0) return false;
         if (Double.compare(that.dy, dy) != 0) return false;
         if (nx != that.nx) return false;

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/VortexTimeRecord.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/VortexTimeRecord.java
@@ -1,0 +1,61 @@
+package mil.army.usace.hec.vortex;
+
+import hec.heclib.dss.DSSPathname;
+import hec.heclib.util.HecTime;
+import mil.army.usace.hec.vortex.util.TimeConverter;
+
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.util.logging.Logger;
+
+public record VortexTimeRecord(ZonedDateTime startTime, ZonedDateTime endTime) {
+    private static final Logger logger = Logger.getLogger(VortexTimeRecord.class.getName());
+
+    public static VortexTimeRecord of(DSSPathname dssPathname) {
+        HecTime hecStart = new HecTime(dssPathname.dPart());
+        HecTime hecEnd = new HecTime(dssPathname.ePart());
+
+        if (!hecStart.isDefined()) {
+            logger.warning("No start time found");
+            return null;
+        }
+
+        if (!hecEnd.isDefined())
+            hecEnd = hecStart;
+
+        ZonedDateTime start = TimeConverter.toZonedDateTime(hecStart);
+        ZonedDateTime end = TimeConverter.toZonedDateTime(hecEnd);
+        return new VortexTimeRecord(start, end);
+    }
+
+    public static VortexTimeRecord of(VortexData vortexData) {
+        ZonedDateTime start = vortexData.startTime();
+        ZonedDateTime end = vortexData.endTime();
+        return new VortexTimeRecord(start, end);
+    }
+
+    public Duration getRecordDuration() {
+        return Duration.between(startTime, endTime);
+    }
+
+    public double getPercentOverlapped(long start, long end) {
+        long overlapDuration = getOverlapDuration(start, end).toSeconds();
+        long recordDuration = getRecordDuration().toSeconds();
+        return (double) overlapDuration / recordDuration;
+    }
+
+    public Duration getOverlapDuration(long start, long end) {
+        long recordStart = startTime.toEpochSecond();
+        long recordEnd = endTime.toEpochSecond();
+
+        long overlapStart = Math.max(start, recordStart);
+        long overlapEnd = Math.min(end, recordEnd);
+        long overlapDuration =  overlapEnd > overlapStart ? overlapEnd - overlapStart : 0;
+
+        return Duration.ofSeconds(overlapDuration);
+    }
+
+    public boolean hasOverlap(long start, long end) {
+        return getOverlapDuration(start, end).toSeconds() > 0;
+    }
+}

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/AscDataReader.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/AscDataReader.java
@@ -3,6 +3,7 @@ package mil.army.usace.hec.vortex.io;
 import mil.army.usace.hec.vortex.GdalRegister;
 import mil.army.usace.hec.vortex.VortexData;
 import mil.army.usace.hec.vortex.VortexGrid;
+import mil.army.usace.hec.vortex.VortexTimeRecord;
 import mil.army.usace.hec.vortex.util.FilenameUtil;
 import org.gdal.gdal.Band;
 import org.gdal.gdal.Dataset;
@@ -301,5 +302,13 @@ class AscDataReader extends DataReader {
         else {
             return null;
         }
+    }
+
+    @Override
+    public List<VortexTimeRecord> getTimeRecords() {
+        return getDtos()
+                .stream()
+                .map(VortexTimeRecord::of)
+                .toList();
     }
 }

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/AscZipDataReader.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/AscZipDataReader.java
@@ -2,6 +2,7 @@ package mil.army.usace.hec.vortex.io;
 
 import mil.army.usace.hec.vortex.GdalRegister;
 import mil.army.usace.hec.vortex.VortexData;
+import mil.army.usace.hec.vortex.VortexTimeRecord;
 import org.gdal.gdal.gdal;
 
 import java.io.File;
@@ -74,5 +75,12 @@ public class AscZipDataReader extends DataReader implements VirtualFileSystem{
         }
         return null;
     } // Extended getDto(): Asc Zip
+
+    @Override
+    public List<VortexTimeRecord> getTimeRecords() {
+        return getDtos().stream()
+                .map(VortexTimeRecord::of)
+                .toList();
+    }
 
 } // AscZipDataReader class

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/BilDataReader.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/BilDataReader.java
@@ -3,6 +3,7 @@ package mil.army.usace.hec.vortex.io;
 import mil.army.usace.hec.vortex.GdalRegister;
 import mil.army.usace.hec.vortex.VortexData;
 import mil.army.usace.hec.vortex.VortexGrid;
+import mil.army.usace.hec.vortex.VortexTimeRecord;
 import org.gdal.gdal.Band;
 import org.gdal.gdal.Dataset;
 import org.gdal.gdal.TranslateOptions;
@@ -271,5 +272,12 @@ class BilDataReader extends DataReader {
         else {
             return null;
         }
+    }
+
+    @Override
+    public List<VortexTimeRecord> getTimeRecords() {
+        return getDtos().stream()
+                .map(VortexTimeRecord::of)
+                .toList();
     }
 } // BilDataReader class

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/BilZipDataReader.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/BilZipDataReader.java
@@ -2,6 +2,7 @@ package mil.army.usace.hec.vortex.io;
 
 import mil.army.usace.hec.vortex.GdalRegister;
 import mil.army.usace.hec.vortex.VortexData;
+import mil.army.usace.hec.vortex.VortexTimeRecord;
 import org.gdal.gdal.gdal;
 
 import java.io.File;
@@ -77,5 +78,12 @@ public class BilZipDataReader extends DataReader implements VirtualFileSystem{
         }
         return null;
     } // Extended getDto(): Bil Zip
+
+    @Override
+    public List<VortexTimeRecord> getTimeRecords() {
+        return getDtos().stream()
+                .map(VortexTimeRecord::of)
+                .toList();
+    }
 
 } // BilZipDataReader class

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/BufferedDataReader.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/BufferedDataReader.java
@@ -1,0 +1,77 @@
+package mil.army.usace.hec.vortex.io;
+
+import mil.army.usace.hec.vortex.VortexData;
+import mil.army.usace.hec.vortex.VortexGrid;
+import mil.army.usace.hec.vortex.VortexTimeRecord;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
+
+public class BufferedDataReader {
+    private static final Logger logger = Logger.getLogger(BufferedDataReader.class.getName());
+
+    private final DataReader dataReader;
+    private final int numGrids;
+    private final VortexGrid baseGrid;
+
+    private final List<VortexGrid> buffer = new ArrayList<>();
+    private int bufferStartIndex = -1;
+    private static final int MAX_BUFFER_SIZE = 10;
+
+    public BufferedDataReader(String pathToFile, String pathToData) {
+        dataReader = DataReader.builder()
+                .path(pathToFile)
+                .variable(pathToData)
+                .build();
+        this.numGrids = dataReader.getDtoCount();
+        this.baseGrid = get(0);
+    }
+
+    /* Public Methods */
+    public VortexGrid get(int index) {
+        if (index < 0 || index >= getCount()) {
+            logger.warning("Out of range index");
+            return null;
+        }
+
+        boolean isInBuffer = (index >= bufferStartIndex) && (index < (bufferStartIndex + buffer.size()));
+        if (!isInBuffer) loadBuffer(index);
+        int bufferIndex = index - bufferStartIndex;
+        return buffer.get(bufferIndex);
+    }
+
+    public int getCount() {
+        return numGrids;
+    }
+
+    /* Utility Methods */
+    private void loadBuffer(int index) {
+        // Reset buffer
+        buffer.clear();
+        bufferStartIndex = index;
+
+        // Load buffer
+        int maxDataIndex = getCount();
+        int maxBufferIndex = index + MAX_BUFFER_SIZE;
+        int endIndex = Math.min(maxBufferIndex, maxDataIndex);
+
+        for (int i = index; i < endIndex; i++) {
+            VortexData data = dataReader.getDto(i);
+            if (data instanceof VortexGrid grid)
+                buffer.add(grid);
+        }
+    }
+
+    public List<VortexTimeRecord> getTimeRecords() {
+        return dataReader.getTimeRecords();
+    }
+
+    public VortexGrid getBaseGrid() {
+        return baseGrid;
+    }
+
+    public String getPathToFile() {
+        return dataReader.path;
+    }
+}

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/DataReader.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/DataReader.java
@@ -1,6 +1,7 @@
 package mil.army.usace.hec.vortex.io;
 
 import mil.army.usace.hec.vortex.VortexData;
+import mil.army.usace.hec.vortex.VortexTimeRecord;
 
 import java.io.File;
 import java.util.List;
@@ -95,6 +96,8 @@ public abstract class DataReader {
     public abstract int getDtoCount();
 
     public abstract VortexData getDto(int idx);
+
+    public abstract List<VortexTimeRecord> getTimeRecords();
 
     public static boolean isVariableRequired(String pathToFile) {
         String fileName = new File(pathToFile).getName().toLowerCase();

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/DssDataReader.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/DssDataReader.java
@@ -3,11 +3,11 @@ package mil.army.usace.hec.vortex.io;
 import hec.heclib.dss.*;
 import hec.heclib.grid.GridData;
 import hec.heclib.grid.GridInfo;
-import hec.heclib.grid.GridUtilities;
 import hec.heclib.grid.GriddedData;
 import hec.heclib.util.Heclib;
 import mil.army.usace.hec.vortex.VortexData;
 import mil.army.usace.hec.vortex.VortexGrid;
+import mil.army.usace.hec.vortex.VortexTimeRecord;
 import mil.army.usace.hec.vortex.geo.RasterUtils;
 import mil.army.usace.hec.vortex.geo.ReferenceUtils;
 import mil.army.usace.hec.vortex.geo.WktFactory;
@@ -19,10 +19,14 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.*;
+import java.util.logging.Logger;
+import java.util.stream.IntStream;
 
 import static hec.heclib.dss.HecDSSDataAttributes.*;
 
 class DssDataReader extends DataReader {
+    private static final Logger logger = Logger.getLogger(DssDataReader.class.getName());
+    private List<String> catalogPathnameList = null;
 
     DssDataReader(DataReaderBuilder builder) {
         super(builder);
@@ -30,29 +34,9 @@ class DssDataReader extends DataReader {
 
     @Override
     public List<VortexData> getDtos() {
-        HecDSSFileAccess.setDefaultDSSFileName(path);
-        String[] paths;
-        if (variableName.contains("*")) {
-            HecDssCatalog catalog = new HecDssCatalog();
-            paths = catalog.getCatalog(true, variableName);
-        } else {
-            paths = new String[1];
-            paths[0] = variableName;
-        }
-        List<VortexData> dtos = new ArrayList<>();
-        Arrays.stream(paths).forEach(path -> {
-            int[] status = new int[1];
-            GriddedData griddedData = new GriddedData();
-            griddedData.setDSSFileName(this.path);
-            griddedData.setPathname(path);
-            GridData gridData = new GridData();
-            griddedData.retrieveGriddedData(true, gridData, status);
-            if (status[0] == 0) {
-                dtos.add(dssToDto(gridData, path));
-            }
-
-        });
-        return dtos;
+        return IntStream.range(0, getDtoCount())
+                .mapToObj(this::getDto)
+                .toList();
     }
 
     private VortexGrid dssToDto(GridData gridData, String pathname){
@@ -66,7 +50,7 @@ class DssDataReader extends DataReader {
         int direction = ReferenceUtils.getUlyDirection(wkt, ulx, lly);
         double uly = lly + direction * ny * cellSize;
 
-        DSSPathname dssPathname = new DSSPathname(variableName);
+        DSSPathname dssPathname = new DSSPathname(pathname);
         String pathName = dssPathname.getPathname();
         String variable = dssPathname.cPart();
 
@@ -83,10 +67,18 @@ class DssDataReader extends DataReader {
             startTime = ZonedDateTime.of(LocalDateTime.parse(gridInfo.getStartTime(), formatter), ZoneId.of("UTC"));
             try {
                 endTime = ZonedDateTime.of(LocalDateTime.parse(gridInfo.getEndTime(), formatter), ZoneId.of("UTC"));
+                if (endTime.isEqual(ZonedDateTime.parse("1899-12-31T00:00Z[UTC]")))
+                    endTime = startTime;
             } catch (DateTimeParseException e) {
                 endTime = startTime;
             }
             interval = Duration.between(startTime, endTime);
+        }
+
+        VortexTimeRecord timeRecord = VortexTimeRecord.of(dssPathname);
+        if (timeRecord != null) {
+            startTime = timeRecord.startTime();
+            endTime = timeRecord.endTime();
         }
 
         float[] data = RasterUtils.flipVertically(gridData.getData(), nx);
@@ -146,35 +138,74 @@ class DssDataReader extends DataReader {
 
     @Override
     public int getDtoCount() {
-        HecDSSFileAccess.setDefaultDSSFileName(path);
-        String[] paths;
-        if (variableName.contains("*")) {
-            HecDssCatalog catalog = new HecDssCatalog();
-            paths = catalog.getCatalog(true, variableName);
-        } else {
-            paths = new String[1];
-            paths[0] = variableName;
-        }
-        return paths.length;
+        return getRecordPathnameList().size();
     }
 
     @Override
     public VortexData getDto(int idx) {
-        HecDSSFileAccess.setDefaultDSSFileName(path);
-        String[] paths;
-        if (variableName.contains("*")) {
-            HecDssCatalog catalog = new HecDssCatalog();
-            paths = catalog.getCatalog(true, variableName);
-        } else {
-            paths = new String[1];
-            paths[0] = variableName;
-        }
-        String dssPath = paths[idx];
+        String pathname = getRecordPathnameList().get(idx);
+        GriddedData griddedData = new GriddedData();
+        griddedData.setDSSFileName(path);
+        griddedData.setPathname(pathname);
+
+        GridData gridData = new GridData();
         int[] status = new int[1];
-        GridData gridData = GridUtilities.retrieveGridFromDss(this.path, dssPath, status);
-        if (gridData != null) {
-            return dssToDto(gridData, dssPath);
+        griddedData.retrieveGriddedData(true, gridData, status);
+
+        if (status[0] == 0) {
+            return dssToDto(gridData, pathname);
+        } else {
+            logger.warning("Failed to retrieve gridded data");
+            return null;
         }
-        return null;
+    }
+
+    @Override
+    public List<VortexTimeRecord> getTimeRecords() {
+        return getRecordPathnameList().stream()
+                .map(DSSPathname::new)
+                .map(VortexTimeRecord::of)
+                .toList();
+    }
+
+    private List<String> getRecordPathnameList() {
+        if (catalogPathnameList == null) {
+            HecDataManager dataManager = new HecDataManager(path);
+            String pathnameFilter = getPathnameFilter();
+            String[] paths = dataManager.getCatalog(true, pathnameFilter);
+            dataManager.done();
+
+            catalogPathnameList = Arrays.stream(paths)
+                    .sorted(this::comparePathname)
+                    .toList();
+        }
+
+        return catalogPathnameList;
+    }
+
+    private String getPathnameFilter() {
+        if (variableName.equals("*")) return variableName;
+        DSSPathname dssPathname = new DSSPathname(variableName);
+        // Getting records for all times
+        dssPathname.setDPart("*");
+        dssPathname.setEPart("*");
+        return dssPathname.getPathname();
+    }
+
+    private int comparePathname(String pathname1, String pathname2) {
+        VortexTimeRecord record1 = VortexTimeRecord.of(new DSSPathname(pathname1));
+        VortexTimeRecord record2 = VortexTimeRecord.of(new DSSPathname(pathname2));
+
+        if (record1 == null || record2 == null) return 0;
+
+        long startTime1 = record1.startTime().toEpochSecond();
+        long startTime2 = record2.startTime().toEpochSecond();
+
+        long interval1 = record1.endTime().toEpochSecond() - startTime1;
+        long interval2 = record2.endTime().toEpochSecond() - startTime2;
+
+        int startTimeComparison = Long.compare(startTime1, startTime2);
+
+        return (startTimeComparison != 0) ? startTimeComparison : Long.compare(interval1, interval2);
     }
 }

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/NetcdfDataReader.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/NetcdfDataReader.java
@@ -2,6 +2,7 @@ package mil.army.usace.hec.vortex.io;
 
 import mil.army.usace.hec.vortex.VortexData;
 import mil.army.usace.hec.vortex.VortexGrid;
+import mil.army.usace.hec.vortex.VortexTimeRecord;
 import mil.army.usace.hec.vortex.geo.*;
 import mil.army.usace.hec.vortex.util.TimeConverter;
 import org.locationtech.jts.geom.Coordinate;
@@ -124,6 +125,13 @@ public class NetcdfDataReader extends DataReader {
         }
 
         return null;
+    }
+
+    @Override
+    public List<VortexTimeRecord> getTimeRecords() {
+        return getDtos().stream()
+                .map(VortexTimeRecord::of)
+                .toList();
     }
 
     @Override

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/SnodasDataReader.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/SnodasDataReader.java
@@ -3,6 +3,7 @@ package mil.army.usace.hec.vortex.io;
 import mil.army.usace.hec.vortex.GdalRegister;
 import mil.army.usace.hec.vortex.VortexData;
 import mil.army.usace.hec.vortex.VortexGrid;
+import mil.army.usace.hec.vortex.VortexTimeRecord;
 import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.gdal.gdal.Band;
@@ -57,6 +58,13 @@ class SnodasDataReader extends DataReader {
         else
             return null;
     } // getDto()
+
+    @Override
+    public List<VortexTimeRecord> getTimeRecords() {
+        return getDtos().stream()
+                .map(VortexTimeRecord::of)
+                .toList();
+    }
 
     private static Map<String,String> parseFile(String fileName) {
         Map<String,String> info = new HashMap<>();

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/SnodasTarDataReader.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/SnodasTarDataReader.java
@@ -2,6 +2,7 @@ package mil.army.usace.hec.vortex.io;
 
 import mil.army.usace.hec.vortex.GdalRegister;
 import mil.army.usace.hec.vortex.VortexData;
+import mil.army.usace.hec.vortex.VortexTimeRecord;
 import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
@@ -81,6 +82,13 @@ class SnodasTarDataReader extends DataReader implements VirtualFileSystem{
 
         return null;
     } // getDto()
+
+    @Override
+    public List<VortexTimeRecord> getTimeRecords() {
+        return getDtos().stream()
+                .map(VortexTimeRecord::of)
+                .toList();
+    }
 
     private void updateTar(String pathToFile) throws IOException {
         // Get DirectoryPath, TarFilePath, and TarFileName

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/TemporalDataReader.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/TemporalDataReader.java
@@ -1,0 +1,229 @@
+package mil.army.usace.hec.vortex.io;
+
+import mil.army.usace.hec.vortex.VortexDataType;
+import mil.army.usace.hec.vortex.VortexGrid;
+import mil.army.usace.hec.vortex.VortexTimeRecord;
+import mil.army.usace.hec.vortex.geo.Grid;
+import mil.army.usace.hec.vortex.math.GridDataProcessor;
+
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.util.*;
+import java.util.logging.Logger;
+import java.util.stream.IntStream;
+
+public class TemporalDataReader {
+    private static final Logger logger = Logger.getLogger(TemporalDataReader.class.getName());
+
+    private final BufferedDataReader bufferedReader;
+    public final List<VortexTimeRecord> recordList;
+    private final TreeMap<Long, Integer> instantDataTree = new TreeMap<>();
+
+    /* Constructors */
+    public TemporalDataReader(String pathToFile, String pathToData) {
+        this(new BufferedDataReader(pathToFile, pathToData));
+    }
+
+    public TemporalDataReader(BufferedDataReader bufferedReader) {
+        this.bufferedReader = bufferedReader;
+        this.recordList = bufferedReader.getTimeRecords();
+        initDataTree();
+    }
+
+    private void initDataTree() {
+        List<VortexTimeRecord> timeRecords = bufferedReader.getTimeRecords();
+
+        for (int i = 0; i < timeRecords.size(); i++) {
+            VortexTimeRecord timeRecord = timeRecords.get(i);
+            long startTime = timeRecord.startTime().toEpochSecond();
+            long endTime = timeRecord.endTime().toEpochSecond();
+            if (startTime == endTime) instantDataTree.put(startTime, i);
+        }
+    }
+
+    /* Public API */
+    public VortexGrid read(ZonedDateTime startTime, ZonedDateTime endTime) {
+        VortexGrid baseGrid = bufferedReader.getBaseGrid();
+        VortexDataType dataType = baseGrid.dataType();
+        return read(dataType, startTime, endTime);
+    }
+
+    public VortexGrid[] getMinMaxGridData(ZonedDateTime startTime, ZonedDateTime endTime) {
+        VortexGrid baseGrid = bufferedReader.getBaseGrid();
+        VortexDataType dataType = baseGrid.dataType();
+        return getMinMaxGridData(dataType, startTime, endTime);
+    }
+
+    public Grid getGridDefinition() {
+        VortexGrid baseGrid = bufferedReader.getBaseGrid();
+
+        return Grid.builder()
+                .dx(baseGrid.dx())
+                .dy(baseGrid.dy())
+                .nx(baseGrid.nx())
+                .ny(baseGrid.ny())
+                .originX(baseGrid.originX())
+                .originY(baseGrid.originY())
+                .crs(baseGrid.wkt())
+                .build();
+    }
+
+    public String getPathToFile() {
+        return bufferedReader.getPathToFile();
+    }
+
+    /* Read Methods */
+    private VortexGrid read(VortexDataType dataType, ZonedDateTime startTime, ZonedDateTime endTime) {
+        long start = startTime.toEpochSecond();
+        long end = endTime.toEpochSecond();
+
+        return switch (dataType) {
+            case ACCUMULATION -> readAccumulationData(start, end);
+            case AVERAGE -> readAverageData(start, end);
+            case INSTANTANEOUS -> readInstantaneousData(start, end);
+            default -> null;
+        };
+    }
+
+    private VortexGrid readAccumulationData(long startTime, long endTime) {
+        List<VortexGrid> relevantGrids = getRelevantGrids(startTime, endTime);
+        float[] data = GridDataProcessor.calculateWeightedAccumulation(relevantGrids, startTime, endTime);
+        return GridDataProcessor.buildGrid(bufferedReader.getBaseGrid(), startTime, endTime, data);
+    }
+
+    private VortexGrid readAverageData(long startTime, long endTime) {
+        List<VortexGrid> relevantGrids = getRelevantGrids(startTime, endTime);
+        float[] data = GridDataProcessor.calculateWeightedAverage(relevantGrids, startTime, endTime);
+        return GridDataProcessor.buildGrid(bufferedReader.getBaseGrid(), startTime, endTime, data);
+    }
+
+    private VortexGrid readInstantaneousData(long startTime, long endTime) {
+        return startTime == endTime ? readPointInstantData(startTime) : readPeriodInstantData(startTime, endTime);
+    }
+
+    private VortexGrid readPointInstantData(long time) {
+        List<VortexGrid> relevantGrids = queryPointInstantData(time);
+        float[] data = GridDataProcessor.calculatePointInstant(relevantGrids, time);
+        return GridDataProcessor.buildGrid(bufferedReader.getBaseGrid(), time, time, data);
+    }
+
+    private VortexGrid readPeriodInstantData(long startTime, long endTime) {
+        List<VortexGrid> relevantGrids = queryPeriodInstantData(startTime, endTime, true, true);
+        float[] data = GridDataProcessor.calculatePeriodInstant(relevantGrids, startTime, endTime);
+        return GridDataProcessor.buildGrid(bufferedReader.getBaseGrid(), startTime, endTime, data);
+    }
+
+    /* Get Min & Max Methods */
+    private VortexGrid[] getMinMaxGridData(VortexDataType dataType, ZonedDateTime startTime, ZonedDateTime endTime) {
+        long start = startTime.toEpochSecond();
+        long end = endTime.toEpochSecond();
+
+        return switch (dataType) {
+            case ACCUMULATION, AVERAGE -> getMinMaxForPeriodGrids(start, end);
+            case INSTANTANEOUS -> getMinMaxForInstantGrids(start, end);
+            default -> null;
+        };
+    }
+
+    private VortexGrid[] getMinMaxForPeriodGrids(long startTime, long endTime) {
+        List<VortexGrid> relevantGrids = getRelevantGrids(startTime, endTime);
+        return buildMinMaxGrids(relevantGrids, startTime, endTime);
+    }
+
+    private VortexGrid[] getMinMaxForInstantGrids(long startTime, long endTime) {
+        List<VortexGrid> relevantGrids = queryPeriodInstantData(startTime, endTime, true, false).stream()
+                .filter(g -> g.startTime().toEpochSecond() >= startTime)
+                .toList();
+        return buildMinMaxGrids(relevantGrids, startTime, endTime);
+    }
+
+    private VortexGrid[] buildMinMaxGrids(List<VortexGrid> grids, long startTime, long endTime) {
+        float[][] minMaxData = GridDataProcessor.getMinMaxForGrids(grids);
+        float[] minData = minMaxData[0];
+        float[] maxData = minMaxData[1];
+
+        VortexGrid minGrid = GridDataProcessor.buildGrid(bufferedReader.getBaseGrid(), startTime, endTime, minData);
+        VortexGrid maxGrid = GridDataProcessor.buildGrid(bufferedReader.getBaseGrid(), startTime, endTime, maxData);
+
+        return new VortexGrid[] {minGrid, maxGrid};
+    }
+
+    /* Helpers */
+    private List<VortexGrid> getRelevantGrids(long startTime, long endTime) {
+        List<VortexGrid> relevantGrids = new ArrayList<>();
+        long coveredUntil = startTime;
+
+        List<Integer> overlappedAndSortedIndices = getOverlappedAndSortedIndices(startTime, endTime);
+
+        for (int index : overlappedAndSortedIndices) {
+            VortexTimeRecord timeRecord = recordList.get(index);
+            long recordStart = timeRecord.startTime().toEpochSecond();
+            long recordEnd = timeRecord.endTime().toEpochSecond();
+
+            boolean isRelevant = recordEnd > coveredUntil && recordStart <= coveredUntil;
+
+            if (isRelevant) {
+                relevantGrids.add(bufferedReader.get(index));
+                coveredUntil = recordEnd;
+            }
+
+            if (coveredUntil >= endTime) {
+                break;
+            }
+        }
+
+        return relevantGrids;
+    }
+
+    private List<Integer> getOverlappedAndSortedIndices(long startTime, long endTime) {
+        return IntStream.range(0, recordList.size())
+                .filter(i -> recordList.get(i).hasOverlap(startTime, endTime))
+                .boxed()
+                .sorted((i1, i2) -> {
+                    Duration duration1 = recordList.get(i1).getRecordDuration();
+                    Duration duration2 = recordList.get(i2).getRecordDuration();
+                    return duration1.compareTo(duration2);
+                })
+                .toList();
+    }
+
+    private List<VortexGrid> queryPointInstantData(long time) {
+        Map.Entry<Long, Integer> floorEntry = instantDataTree.floorEntry(time);
+        Map.Entry<Long, Integer> ceilingEntry = instantDataTree.ceilingEntry(time);
+
+        if (floorEntry == null || ceilingEntry == null) {
+            logger.info("Unable to find overlapped instant grid(s)");
+            return Collections.emptyList();
+        }
+
+        VortexGrid floorGrid = bufferedReader.get(floorEntry.getValue());
+        VortexGrid ceilingGrid = bufferedReader.get(ceilingEntry.getValue());
+
+        if (floorEntry.equals(ceilingEntry))
+            return List.of(floorGrid);
+
+        return List.of(floorGrid, ceilingGrid);
+    }
+
+    private List<VortexGrid> queryPeriodInstantData(long start, long end, boolean startInclusive, boolean endInclusive) {
+        Long adjustedStart = Optional.ofNullable(instantDataTree.floorEntry(start))
+                .map(Map.Entry::getKey)
+                .orElse(start);
+
+        Long adjustedEnd = Optional.ofNullable(instantDataTree.ceilingEntry(end))
+                .map(Map.Entry::getKey)
+                .orElse(end);
+
+        SortedMap<Long, Integer> subMap = instantDataTree.subMap(adjustedStart, startInclusive, adjustedEnd, endInclusive);
+
+        if (subMap == null || subMap.isEmpty()) {
+            logger.info("Unable to find overlapped grid(s) for period instant data");
+            return Collections.emptyList();
+        }
+
+        return subMap.values().stream()
+                .map(bufferedReader::get)
+                .sorted(Comparator.comparing(VortexGrid::startTime))
+                .toList();
+    }
+}

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/math/GridDataProcessor.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/math/GridDataProcessor.java
@@ -1,0 +1,253 @@
+package mil.army.usace.hec.vortex.math;
+
+import hec.heclib.util.Heclib;
+import mil.army.usace.hec.vortex.VortexGrid;
+import mil.army.usace.hec.vortex.VortexTimeRecord;
+import mil.army.usace.hec.vortex.util.TimeConverter;
+
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.logging.Logger;
+
+public class GridDataProcessor {
+    private static final Logger logger = Logger.getLogger(GridDataProcessor.class.getName());
+
+    private GridDataProcessor() {
+        // Utility Class
+    }
+
+    public static float[] calculateWeightedAccumulation(List<VortexGrid> grids, long start, long end) {
+        // Accumulation Data = [Sum of grids' (data * overlap ratio)]
+        if (hasNoTargetData(grids, start, end)) return undefinedGridData();
+        double[] weights = calculateAccumulationWeights(grids, start, end);
+        return calculateWeightedData(grids, weights);
+    }
+
+    public static float[] calculateWeightedAverage(List<VortexGrid> grids, long start, long end) {
+        // Average Data = [Sum of grids' (data * overlap ratio)] / [total overlap ratio]
+        if (hasNoTargetData(grids, start, end)) return undefinedGridData();
+        double[] weights = calculateAverageWeights(grids, start, end);
+        return calculateWeightedData(grids, weights);
+    }
+
+    public static float[] calculatePointInstant(List<VortexGrid> vortexGrids, long time) {
+        // Instant Data = floor grid + (rate of change between floor and ceiling) * (overlap time)
+        if (hasNoTargetData(vortexGrids, time, time)) return undefinedGridData();
+        double[] weights = calculatePointInstantWeights(vortexGrids, time);
+        return calculateWeightedData(vortexGrids, weights);
+    }
+    
+    public static float[] calculatePeriodInstant(List<VortexGrid> grids, long start, long end) {
+        if (hasNoTargetData(grids, start, end)) return undefinedGridData();
+        float[] result = new float[grids.get(0).data().length];
+
+        long remainingStart = start;
+
+        for (int i = 0; i < grids.size() - 1; i++) {
+            VortexGrid grid1 = grids.get(i);
+            VortexGrid grid2 = grids.get(i + 1);
+
+            long avgEnd = grid2.startTime().toEpochSecond();
+            double[] avgData = calculateAverageOfTwoGrids(grid1, grid2, remainingStart, end);
+
+            for (int j = 0; j < avgData.length; j++) {
+                result[j] += avgData[j];
+            }
+
+            remainingStart = avgEnd;
+        }
+
+        int totalInterval = (int) Duration.ofSeconds(end - start).toMinutes();
+        for (int i = 0; i < result.length; i++) {
+            result[i] /= totalInterval;
+        }
+
+        return result;
+    }
+
+    public static float[][] getMinMaxForGrids(List<VortexGrid> grids) {
+        int dataLength = grids.get(0).data().length;
+
+        float[][] minMaxData = new float[2][dataLength];
+        Arrays.fill(minMaxData[0], Float.MAX_VALUE);
+        Arrays.fill(minMaxData[1], -Float.MAX_VALUE);
+
+        for (VortexGrid grid : grids) {
+            float[] currentData = grid.data();
+            for (int i = 0; i < dataLength; i++) {
+                float datum = currentData[i];
+
+                if (grid.isNoDataValue(datum))
+                    continue;
+
+                if (datum < minMaxData[0][i])
+                    minMaxData[0][i] = datum;
+
+                if (datum > minMaxData[1][i])
+                    minMaxData[1][i] = datum;
+            }
+        }
+
+        return minMaxData;
+    }
+
+    /* Helpers */
+    public static VortexGrid buildGrid(VortexGrid baseGrid, long startTime, long endTime, float[] data) {
+        ZonedDateTime start = TimeConverter.toZonedDateTime(startTime, baseGrid.startTime().getZone());
+        ZonedDateTime end = TimeConverter.toZonedDateTime(endTime, baseGrid.endTime().getZone());
+
+        if (data == null || data.length == 0) {
+            data = new float[baseGrid.data().length];
+            Arrays.fill(data, (float) baseGrid.noDataValue());
+        }
+
+        return VortexGrid.builder()
+                .dx(baseGrid.dx())
+                .dy(baseGrid.dy())
+                .nx(baseGrid.nx())
+                .ny(baseGrid.ny())
+                .originX(baseGrid.originX())
+                .originY(baseGrid.originY())
+                .wkt(baseGrid.wkt())
+                .data(data)
+                .noDataValue(baseGrid.noDataValue())
+                .units(baseGrid.units())
+                .fileName(baseGrid.fileName())
+                .shortName(baseGrid.shortName())
+                .fullName(baseGrid.fullName())
+                .description(baseGrid.description())
+                .startTime(start)
+                .endTime(end)
+                .interval(Duration.between(start, end))
+                .dataType(baseGrid.dataType())
+                .build();
+    }
+
+    private static float[] calculateWeightedData(List<VortexGrid> grids, double[] weights) {
+        // Result = data * weight. If any grid's data[i] is NaN, then result[i] is NaN
+        if (grids.isEmpty() || grids.size() != weights.length) {
+            logger.severe("Invalid grids and/or weights");
+            return undefinedGridData();
+        }
+
+        int numGrids = grids.size();
+        int numData = grids.get(0).data().length;
+
+        float[] result = new float[numData];
+
+        for (int gridIndex = 0; gridIndex < numGrids; gridIndex++) {
+            VortexGrid grid = grids.get(gridIndex);
+            float[] gridData = grid.data();
+
+            for (int dataIndex = 0; dataIndex < numData; dataIndex++) {
+                double data = gridData[dataIndex];
+                boolean isNaN = grid.isNoDataValue(result[dataIndex]) || grid.isNoDataValue(data);
+
+                if (!isNaN) {
+                    double weightedData = gridData[dataIndex] * weights[gridIndex];
+                    result[dataIndex] += weightedData;
+                } else {
+                    result[dataIndex] = (float) grid.noDataValue();
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private static double[] calculatePointInstantWeights(List<VortexGrid> vortexGrids, long targetTime) {
+        return switch (vortexGrids.size()) {
+            case 1 -> new double[] {1f};
+            case 2 -> {
+                VortexGrid floorGrid = vortexGrids.get(0);
+                VortexGrid ceilingGrid = vortexGrids.get(1);
+                long grid1Time = floorGrid.startTime().toEpochSecond();
+                long grid2Time = ceilingGrid.startTime().toEpochSecond();
+                double fraction = (double) (targetTime - grid1Time) / (grid2Time - grid1Time);
+                yield  new double[] {1 - fraction, fraction};
+            }
+            default -> {
+                logger.severe("Should not have more than two grids to interpolate");
+                yield new double[0];
+            }
+        };
+    }
+
+    private static double[] calculateAccumulationWeights(List<VortexGrid> grids, long start, long end) {
+        return grids.stream()
+                .map(VortexTimeRecord::of)
+                .mapToDouble(timeRecord -> timeRecord.getPercentOverlapped(start, end))
+                .toArray();
+    }
+
+    private static double[] calculateAverageWeights(List<VortexGrid> grids, long start, long end) {
+        double[] ratios = new double[grids.size()];
+
+        List<VortexTimeRecord> timeRecords = grids.stream().map(VortexTimeRecord::of).toList();
+        long totalDuration = end - start;
+
+        for (int i = 0; i < timeRecords.size(); i++) {
+            VortexTimeRecord timeRecord = timeRecords.get(i);
+            double overlapDuration = timeRecord.getOverlapDuration(start, end).toSeconds();
+            double ratio = overlapDuration / totalDuration;
+            ratios[i] = ratio;
+        }
+
+        return ratios;
+    }
+
+    private static double[] calculateAverageOfTwoGrids(VortexGrid firstGrid, VortexGrid secondGrid, long start, long end) {
+        VortexTimeRecord timeRecord = new VortexTimeRecord(firstGrid.startTime(), secondGrid.startTime());
+        int overlapInterval = (int) timeRecord.getOverlapDuration(start, end).toMinutes();
+        int wholeInterval = (int) timeRecord.getRecordDuration().toMinutes();
+
+        double percentOverlapped = timeRecord.getPercentOverlapped(start, end);
+        if (Double.isNaN(percentOverlapped) || percentOverlapped == 0) logger.severe("Invalid Overlap Ratio");
+
+        float[] data1 = firstGrid.data();
+        float[] data2 = secondGrid.data();
+        double[] result = new double[data1.length];
+
+        for (int i = 0; i < data1.length; i++) {
+            double value1 = data1[i];
+            double value2 = data2[i];
+
+            if (value1 == Heclib.UNDEFINED_DOUBLE || value2 == Heclib.UNDEFINED_DOUBLE) {
+                result[i] = Heclib.UNDEFINED_DOUBLE;
+                continue;
+            }
+
+            boolean adjustStart = timeRecord.startTime().toEpochSecond() != start;
+            boolean adjustEnd = timeRecord.endTime().toEpochSecond() != end;
+            double difference = value2 - value1;
+
+            value1 = adjustStart ? value2 - overlapInterval * difference / wholeInterval : value1;
+            value2 = adjustEnd ? value1 + overlapInterval * difference / wholeInterval : value2;
+
+            double avg = 0.5 * (value1 + value2) * overlapInterval;
+            result[i] = avg;
+        }
+
+        return result;
+    }
+
+    private static boolean hasNoTargetData(List<VortexGrid> vortexGrids, long targetStart, long targetEnd) {
+        // No grids found for time period [targetStart, targetEnd]
+        if (vortexGrids == null || vortexGrids.isEmpty()) return true;
+
+        VortexGrid firstGrid = vortexGrids.get(0);
+        VortexGrid lastGrid = vortexGrids.get(vortexGrids.size() - 1);
+
+        boolean afterFirstGrid = targetStart >= firstGrid.startTime().toEpochSecond();
+        boolean beforeLastGrid = targetEnd <= lastGrid.endTime().toEpochSecond();
+
+        return !afterFirstGrid || !beforeLastGrid;
+    }
+
+    private static float[] undefinedGridData() {
+        logger.info("Has undefined grid data");
+        return new float[0];
+    }
+}

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/util/TimeConverter.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/util/TimeConverter.java
@@ -3,6 +3,8 @@ package mil.army.usace.hec.vortex.util;
 import hec.heclib.util.HecTime;
 import ucar.nc2.time.CalendarDate;
 
+import java.time.Instant;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Date;
 
@@ -16,6 +18,11 @@ public class TimeConverter {
 
     public static ZonedDateTime toZonedDateTime(CalendarDate calendarDate){
         return ZonedDateTime.parse(calendarDate.toString());
+    }
+
+    public static ZonedDateTime toZonedDateTime(long epochSeconds, ZoneId zoneId) {
+        Instant instant = Instant.ofEpochSecond(epochSeconds);
+        return ZonedDateTime.ofInstant(instant, zoneId);
     }
 
     public static HecTime toHecTime(ZonedDateTime zonedDateTime){

--- a/vortex-api/src/test/java/mil/army/usace/hec/vortex/io/BufferedDataReaderTest.java
+++ b/vortex-api/src/test/java/mil/army/usace/hec/vortex/io/BufferedDataReaderTest.java
@@ -1,0 +1,43 @@
+package mil.army.usace.hec.vortex.io;
+
+import mil.army.usace.hec.vortex.TestUtil;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BufferedDataReaderTest {
+    @Test
+    void GetTest() {
+        File file = TestUtil.getResourceFile("/normalizer/qpe.dss");
+        assertNotNull(file);
+
+        String pathToFile = file.getAbsolutePath();
+        String variableName = "*";
+
+        DataReader dataReader = DataReader.builder()
+                .path(pathToFile)
+                .variable(variableName)
+                .build();
+        BufferedDataReader bufferedReader = new BufferedDataReader(pathToFile, variableName);
+
+        assertEquals(dataReader.getDto(20), bufferedReader.get(20));
+        assertEquals(dataReader.getDto(29), bufferedReader.get(29));
+        assertEquals(dataReader.getDto(0), bufferedReader.get(0));
+        assertEquals(dataReader.getDto(6), bufferedReader.get(6));
+        assertNull(bufferedReader.get(55));
+    }
+
+    @Test
+    void GetCountTest() {
+        File file = TestUtil.getResourceFile("/normalizer/qpe.dss");
+        assertNotNull(file);
+
+        String pathToFile = file.getAbsolutePath();
+        String variableName = "*";
+
+        BufferedDataReader bufferedReader = new BufferedDataReader(pathToFile, variableName);
+        assertEquals(49, bufferedReader.getCount());
+    }
+}

--- a/vortex-api/src/test/java/mil/army/usace/hec/vortex/io/TemporalDataReaderTest.java
+++ b/vortex-api/src/test/java/mil/army/usace/hec/vortex/io/TemporalDataReaderTest.java
@@ -1,0 +1,347 @@
+package mil.army.usace.hec.vortex.io;
+
+import hec.heclib.util.Heclib;
+import mil.army.usace.hec.vortex.*;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.time.Duration;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+import static mil.army.usace.hec.vortex.VortexDataType.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class TemporalDataReaderTest {
+    /* Accumulation Tests */
+    @Test
+    void ReadAccumulationTime_singleGridOverlap() {
+        TemporalDataReader reader = setupAccumulationReader();
+        ZonedDateTime start = buildTestTime(2,0);
+        ZonedDateTime end = buildTestTime(3,0);
+
+        float[] expectedData = buildTestData(1.5f);
+        VortexGrid actualGrid = reader.read(start, end);
+
+        assertFloatArrayEquals(expectedData, actualGrid.data());
+    }
+
+    @Test
+    void ReadAccumulationTime_mixData() {
+        TemporalDataReader reader = setupMixedAccumulationReader();
+        ZonedDateTime start = buildTestTime(10,0);
+        ZonedDateTime end = buildTestTime(10,15);
+
+        float[] expectedData = buildTestData(1.25f);
+        VortexGrid actualGrid = reader.read(start, end);
+
+        assertFloatArrayEquals(expectedData, actualGrid.data());
+    }
+
+    @Test
+    void ReadAccumulationTime_fullOverlap() {
+        TemporalDataReader reader = setupAccumulationReader();
+        ZonedDateTime start = buildTestTime(1,0);
+        ZonedDateTime end = buildTestTime(6,0);
+
+        float[] expectedData = buildTestData(9f);
+        VortexGrid actualGrid = reader.read(start, end);
+
+        assertFloatArrayEquals(expectedData, actualGrid.data());
+    }
+
+    @Test
+    void ReadAccumulationTime_partialFirstGridOverlap() {
+        TemporalDataReader reader = setupAccumulationReader();
+        ZonedDateTime start = buildTestTime(1,30);
+        ZonedDateTime end = buildTestTime(3,0);
+
+        float[] expectedData = buildTestData(2.5f);
+        VortexGrid actualGrid = reader.read(start, end);
+
+        assertFloatArrayEquals(expectedData, actualGrid.data());
+    }
+
+    @Test
+    void ReadAccumulationTime_partialMultipleGridsOverlap() {
+        TemporalDataReader reader = setupAccumulationReader();
+        ZonedDateTime start = buildTestTime(1,15);
+        ZonedDateTime end = buildTestTime(3,15);
+
+        float[] expectedData = buildTestData(3f);
+        VortexGrid actualGrid = reader.read(start, end);
+
+        assertFloatArrayEquals(expectedData, actualGrid.data());
+    }
+
+    @Test
+    void ReadAccumulationTime_beforeStart() {
+        TemporalDataReader reader = setupAccumulationReader();
+        ZonedDateTime start = buildTestTime(0,15);
+        ZonedDateTime end = buildTestTime(3,0);
+
+        VortexGrid actualGrid = reader.read(start, end);
+        assertMissingData(actualGrid);
+    }
+
+    @Test
+    void ReadAccumulationTime_afterEnd() {
+        TemporalDataReader reader = setupAccumulationReader();
+        ZonedDateTime start = buildTestTime(4,30);
+        ZonedDateTime end = buildTestTime(6,15);
+
+        VortexGrid actualGrid = reader.read(start, end);
+        assertMissingData(actualGrid);
+    }
+
+    /* Average Tests */
+    @Test
+    void ReadAverageTime_noOverlap() {
+        TemporalDataReader reader = setupAverageReader();
+        ZonedDateTime start = buildTestTime(7,0);
+        ZonedDateTime end = buildTestTime(8,0);
+
+        VortexGrid actualGrid = reader.read(start, end);
+
+        assertMissingData(actualGrid);
+    }
+
+    @Test
+    void ReadAverageTime_singleGridOverlap() {
+        TemporalDataReader reader = setupAverageReader();
+        ZonedDateTime start = buildTestTime(1,0);
+        ZonedDateTime end = buildTestTime(2,0);
+
+        float[] expectedData = buildTestData(7.5f);
+        VortexGrid actualGrid = reader.read(start, end);
+
+        assertFloatArrayEquals(expectedData, actualGrid.data());
+    }
+
+    @Test
+    void ReadAverageTime_fullOverlap() {
+        TemporalDataReader reader = setupAverageReader();
+        ZonedDateTime start = buildTestTime(1,0);
+        ZonedDateTime end = buildTestTime(6,0);
+
+        float[] expectedData = buildTestData(7.56f);
+        VortexGrid actualGrid = reader.read(start, end);
+
+        assertFloatArrayEquals(expectedData, actualGrid.data());
+    }
+
+    @Test
+    void ReadAverageTime_partialFirstGridOverlap() {
+        TemporalDataReader reader = setupAverageReader();
+        ZonedDateTime start = buildTestTime(1,30);
+        ZonedDateTime end = buildTestTime(3,0);
+
+        float[] expectedData = buildTestData(7.566667f);
+        VortexGrid actualGrid = reader.read(start, end);
+
+        assertFloatArrayEquals(expectedData, actualGrid.data());
+    }
+
+    @Test
+    void ReadAverageTime_partialMultipleGridsOverlap() {
+        TemporalDataReader reader = setupAverageReader();
+        ZonedDateTime start = buildTestTime(1,15);
+        ZonedDateTime end = buildTestTime(3,15);
+
+        float[] expectedData = buildTestData(7.575f);
+        VortexGrid actualGrid = reader.read(start, end);
+
+        assertFloatArrayEquals(expectedData, actualGrid.data());
+    }
+
+    /* Point Instant Tests */
+    @Test
+    void ReadInstantTime_sameGridTime() {
+        TemporalDataReader reader = setupInstantReader();
+        ZonedDateTime time = buildTestTime(2,0);
+
+        float[] expectedData = buildTestData(20f);
+        VortexGrid actualGrid = reader.read(time, time);
+
+        assertFloatArrayEquals(expectedData, actualGrid.data());
+    }
+
+    @Test
+    void ReadInstantTime_betweenGridTimes() {
+        TemporalDataReader reader = setupInstantReader();
+        ZonedDateTime time = buildTestTime(1,15);
+
+        float[] expectedData = buildTestData(16.25f);
+        VortexGrid actualGrid = reader.read(time, time);
+
+        assertFloatArrayEquals(expectedData, actualGrid.data());
+    }
+
+    @Test
+    void ReadInstantTime_beforeFirstGrid() {
+        TemporalDataReader reader = setupInstantReader();
+        ZonedDateTime time = buildTestTime(0,15);
+
+        VortexGrid actualGrid = reader.read(time, time);
+
+        assertMissingData(actualGrid);
+    }
+
+    @Test
+    void ReadInstantTime_afterLastGrid() {
+        TemporalDataReader reader = setupInstantReader();
+        ZonedDateTime time = buildTestTime(5,30);
+
+        VortexGrid actualGrid = reader.read(time, time);
+
+        assertMissingData(actualGrid);
+    }
+
+    /* Period Instant Tests */
+    @Test
+    void ReadPeriodInstantTime_partialMultipleGrids() {
+        TemporalDataReader reader = setupInstantReader();
+        ZonedDateTime start = buildTestTime(2,15);
+        ZonedDateTime end = buildTestTime(4,50);
+
+        float[] expectedData = buildTestData(19.341398f);
+        VortexGrid actualGrid = reader.read(start, end);
+
+        assertFloatArrayEquals(expectedData, actualGrid.data());
+    }
+
+    @Test
+    void ReadPeriodInstantTime_missingDataBefore() {
+        TemporalDataReader reader = setupInstantReader();
+        ZonedDateTime start = buildTestTime(0,30);
+        ZonedDateTime end = buildTestTime(1,0);
+
+        VortexGrid actualGrid = reader.read(start, end);
+
+        assertMissingData(actualGrid);
+    }
+
+    @Test
+    void ReadPeriodInstantTime_missingDataAfter() {
+        TemporalDataReader reader = setupInstantReader();
+        ZonedDateTime start = buildTestTime(5,0);
+        ZonedDateTime end = buildTestTime(6,15);
+
+        VortexGrid actualGrid = reader.read(start, end);
+
+        assertMissingData(actualGrid);
+    }
+
+    /* Helpers */
+    private TemporalDataReader setupAccumulationReader() {
+        List<VortexData> accumulationGrids = List.of(
+                buildTestGrid(ACCUMULATION, 1, 2, 2),
+                buildTestGrid(ACCUMULATION, 2, 3, 1.5f),
+                buildTestGrid(ACCUMULATION, 3, 4, 0),
+                buildTestGrid(ACCUMULATION, 4, 5, 3),
+                buildTestGrid(ACCUMULATION, 5, 6, 2.5f)
+        );
+
+        return new TemporalDataReader(mockDataReader(accumulationGrids));
+    }
+
+    private TemporalDataReader setupMixedAccumulationReader() {
+        List<VortexData> accumulationGrids = List.of(
+                buildTestGrid(ACCUMULATION, 10, 13, 5.23f),
+                buildTestGrid(ACCUMULATION, 10, 11, 5)
+        );
+
+        return new TemporalDataReader(mockDataReader(accumulationGrids));
+    }
+
+    private TemporalDataReader setupAverageReader() {
+        List<VortexData> averageGrids = List.of(
+                buildTestGrid(AVERAGE, 1, 2, 7.5f),
+                buildTestGrid(AVERAGE, 2, 3, 7.6f),
+                buildTestGrid(AVERAGE, 3, 4, 7.7f),
+                buildTestGrid(AVERAGE, 4, 5, 7.4f),
+                buildTestGrid(AVERAGE, 5, 6, 7.6f)
+        );
+
+        return new TemporalDataReader(mockDataReader(averageGrids));
+    }
+
+    private TemporalDataReader setupInstantReader() {
+        List<VortexData> instantGrids = List.of(
+                buildTestGrid(INSTANTANEOUS, 1, 1, 15),
+                buildTestGrid(INSTANTANEOUS, 2, 2, 20),
+                buildTestGrid(INSTANTANEOUS, 3, 3, 18),
+                buildTestGrid(INSTANTANEOUS, 4, 4, 22),
+                buildTestGrid(INSTANTANEOUS, 5, 5, 15)
+        );
+
+        return new TemporalDataReader(mockDataReader(instantGrids));
+    }
+
+    private BufferedDataReader mockDataReader(List<VortexData> gridList) {
+        BufferedDataReader dataReader = Mockito.mock(BufferedDataReader.class);
+        Mockito.when(dataReader.getTimeRecords()).thenReturn(gridList.stream().map(VortexTimeRecord::of).toList());
+        Mockito.when(dataReader.getBaseGrid()).thenReturn((VortexGrid) gridList.get(0));
+        for (int i = 0; i < gridList.size(); i++)
+            Mockito.when(dataReader.get(i)).thenReturn((VortexGrid) gridList.get(i));
+        return dataReader;
+    }
+
+    private VortexGrid buildTestGrid(VortexDataType type, int hourStart, int hourEnd, float dataValue) {
+        float[] data = buildTestData(dataValue);
+
+        ZonedDateTime startTime = buildTestTime(hourStart, 0);
+        ZonedDateTime endTime = buildTestTime(hourEnd, 0);
+
+        return VortexGrid.builder()
+                .dx(1)
+                .dy(1)
+                .nx(3)
+                .ny(3)
+                .originX(0)
+                .originY(0)
+                .wkt("")
+                .data(data)
+                .units("")
+                .fileName("")
+                .shortName("")
+                .fullName("")
+                .description("")
+                .noDataValue(Heclib.UNDEFINED_FLOAT)
+                .startTime(startTime)
+                .endTime(endTime)
+                .interval(Duration.between(startTime, endTime))
+                .dataType(type)
+                .build();
+    }
+
+    private static ZonedDateTime buildTestTime(int hour, int minute) {
+        ZoneId zoneId = ZoneId.of("UTC");
+        return ZonedDateTime.of(2020,1,1, hour, minute,0,0, zoneId);
+    }
+
+    private float[] buildTestData(float value) {
+        float[] data = new float[9];
+        Arrays.fill(data, value);
+        return data;
+    }
+
+    private void assertMissingData(VortexGrid grid) {
+        float[] expectedData = new float[grid.data().length];
+        Arrays.fill(expectedData, (float) grid.noDataValue());
+        assertFloatArrayEquals(expectedData, grid.data());
+    }
+
+    public void assertFloatArrayEquals(float[] expected, float[] actual) {
+        assertEquals(expected.length, actual.length, "Array lengths are different");
+
+        float epsilon = (float) Math.pow(10, -4);
+
+        for (int i = 0; i < expected.length; i++) {
+            assertEquals(expected[i], actual[i], epsilon,
+                    "Arrays differ at index " + i + ". Expected: " + expected[i] + ", but was: " + actual[i]);
+        }
+    }
+}


### PR DESCRIPTION
- Added BufferedDataReader to read and store in memory X amount (currently 10) of VortexGrid objects. 
- Updated DssDataReader::getDto to increase performance by avoiding read of entire DssCatalog for every call. 
- Cached the catalogPathnameList when first initiated to retrieve the corresponding DSS record; it is also used for generating a list of VortexGridRecord. 
- Added DataReader::getTimeRecords to retrieve VortexTimeRecord with only the grid's startTime and endTime - this helps in searching for a particular grid based on time, without needing to store heavy data in memory. 
- Added TemporalDataReader to read grid data based on the specified time or time period.
- TemporalDataReader utilizes BufferedDataReader to get grid data, and thus avoids any possible out of memory errors due to large data being stored in memory. 
- TemporalDataReader uses a TreeRangeMap to store and retrieve the indices of VortexGrids that matches with the specified time period - this helps to reduce search time for relevant grids.
- TemporalDataReader also uses a TreeMap to store indices of VortexGrids, but only for instant grids - where the grid's startTime is equal to its endTime. 
- Based on this setup of using indices and unmodifiable and once-initialized catalogPathList to retrieve specific grid record, we can avoid concurrency issues and be thread-safe.
-  Added a utility class - GridDataProcessor, to calculate time-weighted accumulation and average data for the provided grids and specified time period. 
- The functions to calculate the time weighted data uses linear interpolation to approximate the data in case of partial data. 
- If there is no data in any part of the specified time period, the value for the specified time period would be undefined; this also include the case where the specified time period is out of bounds, or outside available data. 
- The TemporalDataReader uses GridDataProcessor to calculate the grid's data for the specified time.
- Added TemporalDataReaderTest to test read for various grid types (accumulation, average, and instantaneous).

Resolves: HMS-2877