### PR TITLE
Add weasd as SWE variable name

### DIFF
--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/VortexVariable.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/VortexVariable.java
@@ -104,7 +104,7 @@ public enum VortexVariable {
 
     private static boolean isValidSWEName(String shortName) {
         return shortName.contains("snow") && shortName.contains("water") && shortName.contains("equivalent")
-                || shortName.equals("swe");
+                || shortName.equals("swe") || shortName.equals("weasd");
     }
 
     private static boolean isValidSnowfallAccumulationName(String shortName) {

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/DssDataWriter.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/DssDataWriter.java
@@ -369,7 +369,8 @@ public class DssDataWriter extends DataWriter {
         } else if (descriptionLower.contains("snow")
                 && descriptionLower.contains("water")
                 && descriptionLower.contains("equivalent")
-                || descriptionLower.equals("swe")) {
+                || descriptionLower.equals("swe")
+                || descriptionLower.equals("weasd")) {
             return "SWE";
         } else if ((descriptionLower.contains("snowfall"))
                 && (descriptionLower.contains("accumulation"))) {


### PR DESCRIPTION
Add "weasd" as a snow water equivalent variable name. The Twentieth Century Reanalysis Project (20CR) dataset uses the term water equivalent as snow depth (WEASD) to refer to SWE.

Resolves: HMS-3156