### PR TITLE
Generalize properties framework

### DIFF
--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/VortexDataType.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/VortexDataType.java
@@ -19,7 +19,8 @@ public enum VortexDataType {
 
     public static VortexDataType fromString(String dataTypeString) {
         for (VortexDataType type : values()) {
-            if (dataTypeString.equals(type.getDssString()) || dataTypeString.equals(type.getNcString()))
+            dataTypeString = dataTypeString.toLowerCase();
+            if (dataTypeString.contains(type.getDssString()) || dataTypeString.contains(type.getNcString()))
                 return type;
         }
         throw new IllegalArgumentException("dataTypeString not recognized");

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/VortexGrid.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/VortexGrid.java
@@ -79,6 +79,31 @@ public class VortexGrid implements VortexData, Serializable {
         private VortexDataType dataType;
         private VortexVariable variable;
 
+        public VortexGridBuilder() {
+            // Empty constructor
+        }
+
+        public VortexGridBuilder(VortexGrid copy) {
+            dx = copy.dx;
+            dy = copy.dy;
+            nx = copy.nx;
+            ny = copy.ny;
+            originX = copy.originX;
+            originY = copy.originY;
+            wkt = copy.wkt;
+            data = copy.data;
+            noDataValue = copy.noDataValue;
+            units = copy.units;
+            fileName = copy.fileName;
+            shortName = copy.shortName;
+            fullName = copy.fullName;
+            description = copy.description;
+            startTime = copy.startTime;
+            endTime = copy.endTime;
+            interval = copy.interval;
+            dataType = copy.dataType;
+        }
+
         public VortexGridBuilder dx (final double dx) {
             this.dx = dx;
             return this;
@@ -192,6 +217,10 @@ public class VortexGrid implements VortexData, Serializable {
                 default -> VortexDataType.INSTANTANEOUS;
             };
         }
+    }
+
+    public VortexGridBuilder toBuilder() {
+        return new VortexGridBuilder(this);
     }
 
     public static VortexGridBuilder builder(){

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/VortexProperty.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/VortexProperty.java
@@ -1,0 +1,8 @@
+package mil.army.usace.hec.vortex;
+
+public class VortexProperty {
+    public static final String STATUS = "status";
+    public static final String PROGRESS = "progress";
+    public static final String ERROR = "error";
+    public static final String COMPLETE = "complete";
+}

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/geo/IndexSearcher.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/geo/IndexSearcher.java
@@ -91,7 +91,7 @@ public class IndexSearcher {
         domain = geometryCollection.union();
     }
 
-    public int getIndex(double x, double y) {
+    public synchronized int getIndex(double x, double y) {
         GeometryFactory factory = new GeometryFactory();
         Point point = factory.createPoint(new Coordinate(x, y));
 

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/geo/RasterUtils.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/geo/RasterUtils.java
@@ -62,24 +62,9 @@ public class RasterUtils {
             }
         }
 
-        return VortexGrid.builder()
-                .dx(grid.dx())
-                .dy(grid.dy())
-                .nx(grid.nx())
-                .ny(grid.ny())
-                .originX(grid.originX())
-                .originY(grid.originY())
-                .wkt(grid.wkt())
+        return grid.toBuilder()
                 .data(data)
                 .noDataValue(noDataValue)
-                .units(grid.units())
-                .fileName(grid.fileName())
-                .shortName(grid.shortName())
-                .fullName(grid.fullName())
-                .description(grid.description())
-                .startTime(grid.startTime())
-                .endTime(grid.endTime())
-                .interval(grid.interval())
                 .build();
     }
 

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/geo/Resampler.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/geo/Resampler.java
@@ -154,6 +154,8 @@ public class Resampler {
                 .startTime(grid.startTime())
                 .endTime(grid.endTime())
                 .interval(grid.interval())
+                .dataType(grid.dataType())
+                .vortexVariable(grid.vortexVariable())
                 .build();
     }
 

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/geo/Transposer.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/geo/Transposer.java
@@ -261,14 +261,11 @@ public class Transposer {
         transposedResampled.delete();
         resampledBand.delete();
 
-        VortexGrid resampledGrid = VortexGrid.builder()
+        VortexGrid resampledGrid = grid.toBuilder()
                 .dx(resampledDx).dy(resampledDy)
                 .nx(resampledNx).ny(resampledNy)
                 .originX(resampledOriginX).originY(resampledOriginY)
-                .wkt(grid.wkt()).data(resampledData).units(grid.units())
-                .fileName(grid.fileName()).shortName(grid.shortName())
-                .fullName(grid.shortName()).description(grid.description())
-                .startTime(grid.startTime()).endTime(grid.endTime()).interval(grid.interval())
+                .data(resampledData)
                 .build();
 
         if (debug) {

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/AscDataReader.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/AscDataReader.java
@@ -1,8 +1,6 @@
 package mil.army.usace.hec.vortex.io;
 
-import mil.army.usace.hec.vortex.GdalRegister;
-import mil.army.usace.hec.vortex.VortexData;
-import mil.army.usace.hec.vortex.VortexGrid;
+import mil.army.usace.hec.vortex.*;
 import mil.army.usace.hec.vortex.util.FilenameUtil;
 import org.gdal.gdal.Band;
 import org.gdal.gdal.Dataset;
@@ -237,6 +235,9 @@ class AscDataReader extends DataReader {
         dataset.delete();
         band.delete();
 
+        VortexVariable vortexVariable = VortexVariable.fromName(shortName);
+        // FIXME: What should the data type be?
+
         VortexGrid dto = VortexGrid.builder()
                 .dx(dx).dy(dy)
                 .nx(nx).ny(ny)
@@ -253,6 +254,7 @@ class AscDataReader extends DataReader {
                 .startTime(startTime)
                 .endTime(endTime)
                 .interval(interval)
+                .vortexVariable(vortexVariable)
                 .build();
 
         List<VortexData> list = new ArrayList<>();

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/BatchImporter.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/BatchImporter.java
@@ -1,6 +1,7 @@
 package mil.army.usace.hec.vortex.io;
 
 import mil.army.usace.hec.vortex.Options;
+import mil.army.usace.hec.vortex.VortexProperty;
 
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
@@ -18,7 +19,8 @@ public abstract class BatchImporter {
     final Map<String, String> geoOptions;
     final Map<String, String> writeOptions;
 
-    private final PropertyChangeSupport support;
+    final PropertyChangeSupport support;
+    int totalCount;
     private final AtomicInteger doneCount;
 
     BatchImporter(Builder builder) {
@@ -133,18 +135,26 @@ public abstract class BatchImporter {
         return readers;
     }
 
-    PropertyChangeListener writeProgressListener(int totalCount) {
+    List<ImportableUnit> getImportableUnits() {
+        return getDataReaders().stream()
+                .map(reader -> ImportableUnit.builder()
+                        .reader(reader)
+                        .geoOptions(geoOptions)
+                        .destination(destination)
+                        .writeOptions(writeOptions)
+                        .build())
+                .toList();
+    }
+
+    PropertyChangeListener propertyChangeListener() {
         return evt -> {
             // Propagating Write Progress to UI
-            if (evt.getPropertyName().equals(DataWriter.WRITE_COMPLETED)) {
+            if (evt.getPropertyName().equals(ImportableUnit.IMPORT_COMPLETE)) {
                 int newValue = (int) (((float) doneCount.incrementAndGet() / totalCount) * 100);
-                support.firePropertyChange("progress", null, newValue);
+                support.firePropertyChange(VortexProperty.PROGRESS, null, newValue);
             }
 
-            // Propagating Write Error to UI
-            if (evt.getPropertyName().equals(DataWriter.WRITE_ERROR)) {
-                support.firePropertyChange(evt);
-            }
+            support.firePropertyChange(evt);
         };
     }
 

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/BilDataReader.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/BilDataReader.java
@@ -3,6 +3,7 @@ package mil.army.usace.hec.vortex.io;
 import mil.army.usace.hec.vortex.GdalRegister;
 import mil.army.usace.hec.vortex.VortexData;
 import mil.army.usace.hec.vortex.VortexGrid;
+import mil.army.usace.hec.vortex.VortexVariable;
 import org.gdal.gdal.Band;
 import org.gdal.gdal.Dataset;
 import org.gdal.gdal.TranslateOptions;
@@ -208,6 +209,9 @@ class BilDataReader extends DataReader {
         raster.delete();
         band.delete();
 
+        VortexVariable vortexVariable = VortexVariable.fromName(shortName);
+        // FIXME: What should the data type be?
+
         VortexGrid dto = VortexGrid.builder()
                 .dx(dx)
                 .dy(dy)
@@ -226,6 +230,7 @@ class BilDataReader extends DataReader {
                 .startTime(startTime)
                 .endTime(endTime)
                 .interval(interval)
+                .vortexVariable(vortexVariable)
                 .build();
 
         List<VortexData> list = new ArrayList<>();

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/ConcurrentBatchImporter.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/ConcurrentBatchImporter.java
@@ -1,10 +1,10 @@
 package mil.army.usace.hec.vortex.io;
 
-import java.time.Duration;
-import java.time.Instant;
+import mil.army.usace.hec.vortex.VortexProperty;
+import mil.army.usace.hec.vortex.util.Stopwatch;
+
 import java.util.List;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 
 class ConcurrentBatchImporter extends BatchImporter {
     private static final Logger logger = Logger.getLogger(ConcurrentBatchImporter.class.getName());
@@ -15,26 +15,22 @@ class ConcurrentBatchImporter extends BatchImporter {
 
     @Override
     public void process() {
-        Instant start = Instant.now();
+        Stopwatch stopwatch = new Stopwatch();
+        stopwatch.start();
 
-        List<ImportableUnit> importableUnits = getDataReaders().stream()
-                .map(reader -> ImportableUnit.builder()
-                        .reader(reader)
-                        .geoOptions(geoOptions)
-                        .destination(destination)
-                        .writeOptions(writeOptions)
-                        .build())
-                .collect(Collectors.toList());
+        List<ImportableUnit> importableUnits = getImportableUnits();
 
-        int totalCount = importableUnits.size();
+        totalCount = importableUnits.size();
 
         importableUnits.parallelStream().forEach(importableUnit -> {
-            importableUnit.addPropertyChangeListener(writeProgressListener(totalCount));
+            importableUnit.addPropertyChangeListener(propertyChangeListener());
             importableUnit.process();
         });
 
-        long seconds = Duration.between(start, Instant.now()).toSeconds();
-        String timeMessage = String.format("Batch import time: %d:%02d:%02d%n", seconds / 3600, (seconds % 3600) / 60, (seconds % 60));
+        stopwatch.end();
+        String timeMessage = "Batch import time: " + stopwatch;
         logger.info(timeMessage);
+
+        support.firePropertyChange(VortexProperty.COMPLETE, null, null);
     }
 }

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/DataReader.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/DataReader.java
@@ -2,17 +2,23 @@ package mil.army.usace.hec.vortex.io;
 
 import mil.army.usace.hec.vortex.VortexData;
 
+import java.beans.PropertyChangeListener;
+import java.beans.PropertyChangeSupport;
 import java.io.File;
 import java.util.List;
 import java.util.Set;
 
 public abstract class DataReader {
+    final PropertyChangeSupport support;
+
     final String path;
     final String variableName;
 
     DataReader(DataReaderBuilder builder){
         this.path = builder.path;
         this.variableName = builder.variableName;
+
+        support = new PropertyChangeSupport(this);
     } // DataReader builder()
 
     public static class DataReaderBuilder{
@@ -100,5 +106,13 @@ public abstract class DataReader {
         String fileName = new File(pathToFile).getName().toLowerCase();
 
         return !fileName.matches(".*\\.(asc|tif|tiff|bil|bil.zip|asc.zip)$");
+    }
+
+    public void addPropertyChangeListener(PropertyChangeListener pcl) {
+        support.addPropertyChangeListener(pcl);
+    }
+
+    public void removePropertyChangeListener(PropertyChangeListener pcl) {
+        support.removePropertyChangeListener(pcl);
     }
 } // DataReader class

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/DataWriter.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/DataWriter.java
@@ -2,23 +2,23 @@ package mil.army.usace.hec.vortex.io;
 
 import mil.army.usace.hec.vortex.Options;
 import mil.army.usace.hec.vortex.VortexData;
+import mil.army.usace.hec.vortex.VortexProperty;
 
-import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeSupport;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.nio.file.Paths;
-import java.util.*;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 public abstract class DataWriter {
     final PropertyChangeSupport support = new PropertyChangeSupport(this);
     final Path destination;
     final List<VortexData> data;
     final Map<String, String> options = new HashMap<>();
-
-    public static final String WRITE_ERROR = "WriteError";
-    public static final String WRITE_COMPLETED = "WriteCompleted";
 
     DataWriter(Builder builder){
         this.destination = builder.destination;
@@ -105,21 +105,8 @@ public abstract class DataWriter {
 
     public abstract void write();
 
-    /* Property Change */
-    void fireWriteCompleted() {
-        support.firePropertyChange(DataWriter.WRITE_COMPLETED, null, null);
-    }
-
     void fireWriteError(String errorMessage) {
-        support.firePropertyChange(WRITE_ERROR, null, errorMessage);
-    }
-
-    public void addListener(PropertyChangeListener pcl) {
-        support.addPropertyChangeListener(pcl);
-    }
-
-    public void removeListener(PropertyChangeListener pcl) {
-        support.removePropertyChangeListener(pcl);
+        support.firePropertyChange(VortexProperty.ERROR, null, errorMessage);
     }
 }
 

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/DssDataReader.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/DssDataReader.java
@@ -7,7 +7,9 @@ import hec.heclib.grid.GridUtilities;
 import hec.heclib.grid.GriddedData;
 import hec.heclib.util.Heclib;
 import mil.army.usace.hec.vortex.VortexData;
+import mil.army.usace.hec.vortex.VortexDataType;
 import mil.army.usace.hec.vortex.VortexGrid;
+import mil.army.usace.hec.vortex.VortexVariable;
 import mil.army.usace.hec.vortex.geo.RasterUtils;
 import mil.army.usace.hec.vortex.geo.ReferenceUtils;
 import mil.army.usace.hec.vortex.geo.WktFactory;
@@ -66,7 +68,7 @@ class DssDataReader extends DataReader {
         int direction = ReferenceUtils.getUlyDirection(wkt, ulx, lly);
         double uly = lly + direction * ny * cellSize;
 
-        DSSPathname dssPathname = new DSSPathname(variableName);
+        DSSPathname dssPathname = new DSSPathname(pathname);
         String pathName = dssPathname.getPathname();
         String variable = dssPathname.cPart();
 
@@ -92,6 +94,8 @@ class DssDataReader extends DataReader {
         float[] data = RasterUtils.flipVertically(gridData.getData(), nx);
 
         String dssTypeString = DssDataType.fromInt(gridInfo.getDataType()).toString();
+        VortexDataType dataType = VortexDataType.fromString(dssTypeString);
+        VortexVariable vortexVariable = VortexVariable.fromDssName(dssPathname.cPart());
 
         return  VortexGrid.builder()
                 .dx(cellSize)
@@ -110,7 +114,8 @@ class DssDataReader extends DataReader {
                 .startTime(startTime)
                 .endTime(endTime)
                 .interval(interval)
-                .dataType(dssTypeString)
+                .dataType(dataType)
+                .vortexVariable(vortexVariable)
                 .build();
     }
 

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/ImportableUnit.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/ImportableUnit.java
@@ -13,6 +13,8 @@ import java.util.stream.IntStream;
 
 public class ImportableUnit {
 
+    public static final String IMPORT_COMPLETE = "import_complete";
+
     private final DataReader reader;
     private final Map<String,String> geoOptions;
     private final Path destination;
@@ -92,8 +94,11 @@ public class ImportableUnit {
     public void process() {
         GeographicProcessor geoProcessor = new GeographicProcessor(geoOptions);
 
+        reader.addPropertyChangeListener(support::firePropertyChange);
+
         int count = reader.getDtoCount();
-        IntStream.range(0, count).parallel().forEach(i -> {
+
+        for (int i = 0; i < count; i++) {
             VortexGrid grid = (VortexGrid) reader.getDto(i);
             VortexGrid processed = geoProcessor.process(grid);
 
@@ -107,17 +112,17 @@ public class ImportableUnit {
                     .build();
 
             writer.write();
-        });
+        }
 
-        support.firePropertyChange(DataWriter.WRITE_COMPLETED, null, null);
+        support.firePropertyChange(IMPORT_COMPLETE, null, null);
     }
 
     public void addPropertyChangeListener(PropertyChangeListener pcl) {
-        this.support.addPropertyChangeListener(pcl);
+        support.addPropertyChangeListener(pcl);
     }
 
     public void removePropertyChangeListener(PropertyChangeListener pcl) {
-        this.support.removePropertyChangeListener(pcl);
+        support.removePropertyChangeListener(pcl);
     }
 
 }

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/NetcdfDataReader.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/NetcdfDataReader.java
@@ -17,8 +17,6 @@ import ucar.nc2.dt.grid.GridDataset;
 import ucar.nc2.ft.FeatureDataset;
 import ucar.nc2.ft.FeatureDatasetFactoryManager;
 import ucar.nc2.time.CalendarDate;
-import ucar.unidata.geoloc.Projection;
-import ucar.unidata.geoloc.ProjectionImpl;
 
 import javax.measure.IncommensurableException;
 import javax.measure.Unit;
@@ -173,7 +171,6 @@ public class NetcdfDataReader extends DataReader {
                             && ncd.findCoordinateAxis(AxisType.Lat) != null;
 
                     if (!coordinateSystems.isEmpty() || isLatLon) {
-//                        variableWithTimes(variableDS);
                         variableNames.add(variable.getFullName());
                     }
                 }
@@ -183,10 +180,6 @@ public class NetcdfDataReader extends DataReader {
             logger.log(Level.SEVERE, e, e::getMessage);
         }
         return Collections.emptySet();
-    }
-
-    private static Set<String> variableWithTimes(VariableDS variableDS) {
-        return null;
     }
 
     private static boolean isSelectableVariable(Variable variable) {

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/NetcdfDataReader.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/NetcdfDataReader.java
@@ -2,6 +2,7 @@ package mil.army.usace.hec.vortex.io;
 
 import mil.army.usace.hec.vortex.VortexData;
 import mil.army.usace.hec.vortex.VortexGrid;
+import mil.army.usace.hec.vortex.VortexProperty;
 import mil.army.usace.hec.vortex.geo.*;
 import mil.army.usace.hec.vortex.util.TimeConverter;
 import org.locationtech.jts.geom.Coordinate;
@@ -723,13 +724,18 @@ public class NetcdfDataReader extends DataReader {
         if (gcs.isRegularSpatial())
             return slice;
 
+        support.firePropertyChange(VortexProperty.STATUS, null, "ReIndexing");
+
         IndexSearcher indexSearcher = IndexSearcherFactory.INSTANCE.getOrCreate(gcs);
         Coordinate[] coordinates = gridDefinition.getGridCellCentroidCoords();
         float[] data = new float[coordinates.length];
-        for (int i = 0; i < data.length; i++) {
+        int count = data.length;
+        for (int i = 0; i < count; i++) {
             Coordinate coordinate = coordinates[i];
             int index = indexSearcher.getIndex(coordinate.x, coordinate.y);
             data[i] = index >= 0 ? slice[index] : (float) noDataValue;
+            int progress = (int) (((float) i / count) * 100);
+            support.firePropertyChange(VortexProperty.PROGRESS, null, progress);
         }
 
         return data;

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/NetcdfDataReader.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/NetcdfDataReader.java
@@ -1,8 +1,6 @@
 package mil.army.usace.hec.vortex.io;
 
-import mil.army.usace.hec.vortex.VortexData;
-import mil.army.usace.hec.vortex.VortexGrid;
-import mil.army.usace.hec.vortex.VortexProperty;
+import mil.army.usace.hec.vortex.*;
 import mil.army.usace.hec.vortex.geo.*;
 import mil.army.usace.hec.vortex.util.TimeConverter;
 import org.locationtech.jts.geom.Coordinate;
@@ -10,6 +8,7 @@ import ucar.ma2.Array;
 import ucar.nc2.Dimension;
 import ucar.nc2.Variable;
 import ucar.nc2.constants.AxisType;
+import ucar.nc2.constants.CF;
 import ucar.nc2.constants.FeatureType;
 import ucar.nc2.dataset.*;
 import ucar.nc2.dt.GridCoordSystem;
@@ -209,6 +208,9 @@ public class NetcdfDataReader extends DataReader {
         Grid grid = getGrid(gcs);
         String wkt = getWkt(gcs.getProjection());
 
+        VortexDataType vortexDataType = getVortexDataType(variableDs);
+        VortexVariable vortexVariable = VortexVariable.fromName(variable);
+
         List<ZonedDateTime[]> times = getTimeBounds(gcs);
 
         Dimension timeDim = gridDatatype.getTimeDimension();
@@ -250,6 +252,8 @@ public class NetcdfDataReader extends DataReader {
                                             .startTime(startTime)
                                             .endTime(endTime)
                                             .interval(interval)
+                                            .dataType(vortexDataType)
+                                            .vortexVariable(vortexVariable)
                                             .build());
                                 } catch (IOException e) {
                                     logger.log(Level.SEVERE, e, e::getMessage);
@@ -285,6 +289,8 @@ public class NetcdfDataReader extends DataReader {
                             .startTime(startTime)
                             .endTime(endTime)
                             .interval(interval)
+                            .dataType(vortexDataType)
+                            .vortexVariable(vortexVariable)
                             .build());
                 } catch (IOException e) {
                     logger.log(Level.SEVERE, e, e::getMessage);
@@ -335,6 +341,8 @@ public class NetcdfDataReader extends DataReader {
                         .startTime(startTime)
                         .endTime(endTime)
                         .interval(interval)
+                        .dataType(vortexDataType)
+                        .vortexVariable(vortexVariable)
                         .build());
             } catch (IOException e) {
                 logger.log(Level.SEVERE, e, e::getMessage);
@@ -699,6 +707,9 @@ public class NetcdfDataReader extends DataReader {
         // to map values.
         shiftGrid(grid);
 
+        VortexDataType vortexDataType = getVortexDataType(variableDS);
+        VortexVariable vortexVariable = VortexVariable.fromName(variable);
+
         return VortexGrid.builder()
                 .dx(grid.getDx())
                 .dy(grid.getDy())
@@ -717,6 +728,8 @@ public class NetcdfDataReader extends DataReader {
                 .startTime(startTime)
                 .endTime(endTime)
                 .interval(interval)
+                .dataType(vortexDataType)
+                .vortexVariable(vortexVariable)
                 .build();
     }
 
@@ -739,5 +752,10 @@ public class NetcdfDataReader extends DataReader {
         }
 
         return data;
+    }
+
+    private VortexDataType getVortexDataType(VariableDS variableDS) {
+        String cellMethods = variableDS.findAttributeString(CF.CELL_METHODS, "");
+        return VortexDataType.fromString(cellMethods);
     }
 }

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/NetcdfDataReader.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/NetcdfDataReader.java
@@ -211,7 +211,7 @@ public class NetcdfDataReader extends DataReader {
         double noDataValue = variableDs.getFillValue();
 
         Grid grid = getGrid(gcs);
-        String wkt = getWkt(gcs.getProjectionCT());
+        String wkt = getWkt(gcs);
 
         VortexDataType vortexDataType = getVortexDataType(variableDs);
         VortexVariable vortexVariable = VortexVariable.fromName(variable);
@@ -356,9 +356,13 @@ public class NetcdfDataReader extends DataReader {
         return grids;
     }
 
-    private static String getWkt(ProjectionCT projectionCT) {
-        String wkt = projectionCT.getAttributeContainer().findAttributeString("crs_wkt", "");
-        return !wkt.isEmpty() ? wkt : WktFactory.createWkt(projectionCT.getProjection());
+    private static String getWkt(GridCoordSystem gridCoordSystem) {
+        ProjectionCT projectionCT = gridCoordSystem.getProjectionCT();
+        String wkt = Optional.ofNullable(projectionCT)
+                .map(ProjectionCT::getAttributeContainer)
+                .map(c -> c.findAttributeString("crs_wkt", ""))
+                .orElse("");
+        return !wkt.isEmpty() ? wkt : WktFactory.createWkt(gridCoordSystem.getProjection());
     }
 
     private List<ZonedDateTime[]> getTimeBounds(GridCoordSystem gcs) {
@@ -560,7 +564,7 @@ public class NetcdfDataReader extends DataReader {
         double lly = edgesY[edgesY.length - 1];
         double dy = (lly - uly) / ny;
 
-        String wkt = getWkt(coordinateSystem.getProjectionCT());
+        String wkt = getWkt(coordinateSystem);
 
         grid.set(Grid.builder()
                 .nx(nx)
@@ -668,7 +672,7 @@ public class NetcdfDataReader extends DataReader {
         double noDataValue = variableDS.getFillValue();
 
         Grid grid = getGrid(gcs);
-        String wkt = getWkt(gcs.getProjectionCT());
+        String wkt = getWkt(gcs);
 
         List<ZonedDateTime[]> times = getTimeBounds(gcs);
 

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/NetcdfDataReader.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/NetcdfDataReader.java
@@ -173,6 +173,7 @@ public class NetcdfDataReader extends DataReader {
                             && ncd.findCoordinateAxis(AxisType.Lat) != null;
 
                     if (!coordinateSystems.isEmpty() || isLatLon) {
+//                        variableWithTimes(variableDS);
                         variableNames.add(variable.getFullName());
                     }
                 }
@@ -182,6 +183,10 @@ public class NetcdfDataReader extends DataReader {
             logger.log(Level.SEVERE, e, e::getMessage);
         }
         return Collections.emptySet();
+    }
+
+    private static Set<String> variableWithTimes(VariableDS variableDS) {
+        return null;
     }
 
     private static boolean isSelectableVariable(Variable variable) {
@@ -206,7 +211,7 @@ public class NetcdfDataReader extends DataReader {
         double noDataValue = variableDs.getFillValue();
 
         Grid grid = getGrid(gcs);
-        String wkt = getWkt(gcs.getProjection());
+        String wkt = getWkt(gcs.getProjectionCT());
 
         VortexDataType vortexDataType = getVortexDataType(variableDs);
         VortexVariable vortexVariable = VortexVariable.fromName(variable);
@@ -351,8 +356,9 @@ public class NetcdfDataReader extends DataReader {
         return grids;
     }
 
-    private static String getWkt(Projection projection) {
-        return WktFactory.createWkt((ProjectionImpl) projection);
+    private static String getWkt(ProjectionCT projectionCT) {
+        String wkt = projectionCT.getAttributeContainer().findAttributeString("crs_wkt", "");
+        return !wkt.isEmpty() ? wkt : WktFactory.createWkt(projectionCT.getProjection());
     }
 
     private List<ZonedDateTime[]> getTimeBounds(GridCoordSystem gcs) {
@@ -554,7 +560,7 @@ public class NetcdfDataReader extends DataReader {
         double lly = edgesY[edgesY.length - 1];
         double dy = (lly - uly) / ny;
 
-        String wkt = getWkt(coordinateSystem.getProjection());
+        String wkt = getWkt(coordinateSystem.getProjectionCT());
 
         grid.set(Grid.builder()
                 .nx(nx)
@@ -662,7 +668,7 @@ public class NetcdfDataReader extends DataReader {
         double noDataValue = variableDS.getFillValue();
 
         Grid grid = getGrid(gcs);
-        String wkt = getWkt(gcs.getProjection());
+        String wkt = getWkt(gcs.getProjectionCT());
 
         List<ZonedDateTime[]> times = getTimeBounds(gcs);
 

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/NetcdfDataWriter.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/NetcdfDataWriter.java
@@ -1,6 +1,7 @@
 package mil.army.usace.hec.vortex.io;
 
 import mil.army.usace.hec.vortex.VortexGrid;
+import mil.army.usace.hec.vortex.VortexProperty;
 import ucar.nc2.Attribute;
 import ucar.nc2.write.Nc4Chunking;
 import ucar.nc2.write.Nc4ChunkingStrategy;
@@ -67,11 +68,8 @@ public class NetcdfDataWriter extends DataWriter {
     private PropertyChangeListener writerPropertyListener() {
         return e -> {
             String propertyName = e.getPropertyName();
-            if (propertyName.equals(DataWriter.WRITE_COMPLETED)) {
-                fireWriteCompleted();
-            }
 
-            if (propertyName.equals(DataWriter.WRITE_ERROR)) {
+            if (propertyName.equals(VortexProperty.ERROR)) {
                 String errorMessage = String.valueOf(e.getNewValue());
                 fireWriteError(errorMessage);
             }

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/NetcdfDataWriter.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/NetcdfDataWriter.java
@@ -9,12 +9,17 @@ import ucar.nc2.write.NetcdfFileFormat;
 import ucar.nc2.write.NetcdfFormatWriter;
 
 import java.beans.PropertyChangeListener;
+import java.nio.file.Files;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Map;
 
 public class NetcdfDataWriter extends DataWriter {
     private final List<VortexGrid> vortexGridList;
-    private final boolean isOverwrite;
+
+    private static final Map<String, Boolean> fileFirstWriteCompleted = Collections.synchronizedMap(new HashMap<>());
+    private final boolean overwriteExistingFile;
 
     // NetCDF4 Settings
     public static final Nc4Chunking.Strategy CHUNKING_STRATEGY = Nc4Chunking.Strategy.standard;
@@ -25,23 +30,44 @@ public class NetcdfDataWriter extends DataWriter {
     /* Constructor */
     NetcdfDataWriter(Builder builder) {
         super(builder);
-        String overwriteOption = options.get("isOverwrite");
-        isOverwrite = overwriteOption == null || Boolean.parseBoolean(overwriteOption);
+
+        synchronized (NetcdfDataWriter.class) {
+            // Check if file exists and get user preference for overwriting
+            boolean fileExists = Files.exists(destination);
+            boolean userPrefersOverwrite = getOverwritePreference();
+
+            String pathToFile = destination.toString();
+            boolean firstWriteCompleted = fileFirstWriteCompleted.getOrDefault(pathToFile, false);
+
+            if (!fileExists || userPrefersOverwrite && !firstWriteCompleted) {
+                overwriteExistingFile = true;
+                fileFirstWriteCompleted.put(pathToFile, true);
+            } else {
+                overwriteExistingFile = false;
+            }
+        }
+
+
         vortexGridList = data.stream()
                 .filter(VortexGrid.class::isInstance)
                 .map(VortexGrid.class::cast)
-                .collect(Collectors.toList());
+                .toList();
+    }
+
+    private boolean getOverwritePreference() {
+        String overwriteOption = options.get("isOverwrite");
+        return overwriteOption == null || Boolean.parseBoolean(overwriteOption);
     }
 
     /* Write */
     @Override
     public void write() {
-        if (isOverwrite) overwriteData();
+        if (overwriteExistingFile) overwriteData();
         else appendData();
     }
 
     private void overwriteData() {
-        NetcdfFormatWriter.Builder writerBuilder = initWriterBuilder(isOverwrite);
+        NetcdfFormatWriter.Builder writerBuilder = initWriterBuilder();
         addGlobalAttributes(writerBuilder);
 
         NetcdfGridWriter gridWriter = new NetcdfGridWriter(vortexGridList);
@@ -50,16 +76,17 @@ public class NetcdfDataWriter extends DataWriter {
     }
 
     public void appendData() {
-        NetcdfFormatWriter.Builder writerBuilder = initWriterBuilder(isOverwrite);
+        NetcdfFormatWriter.Builder writerBuilder = initWriterBuilder();
+
         NetcdfGridWriter gridWriter = new NetcdfGridWriter(vortexGridList);
         gridWriter.addListener(writerPropertyListener());
         gridWriter.appendData(writerBuilder);
     }
 
-    private NetcdfFormatWriter.Builder initWriterBuilder(boolean isOverwrite) {
+    private NetcdfFormatWriter.Builder initWriterBuilder() {
         Nc4Chunking chunker = Nc4ChunkingStrategy.factory(CHUNKING_STRATEGY, DEFLATE_LEVEL, SHUFFLE);
         return NetcdfFormatWriter.builder()
-                .setNewFile(isOverwrite)
+                .setNewFile(overwriteExistingFile)
                 .setFormat(NETCDF_FORMAT)
                 .setLocation(destination.toString())
                 .setChunker(chunker);

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/NetcdfGridWriter.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/NetcdfGridWriter.java
@@ -1,5 +1,6 @@
 package mil.army.usace.hec.vortex.io;
 
+import mil.army.usace.hec.vortex.VortexProperty;
 import mil.army.usace.hec.vortex.VortexVariable;
 import mil.army.usace.hec.vortex.VortexGrid;
 import mil.army.usace.hec.vortex.VortexGridCollection;
@@ -147,7 +148,6 @@ public class NetcdfGridWriter {
                     VortexGrid grid = entry.getValue();
                     int[] origin = {index, 0, 0};
                     writer.write(variable, origin, Array.makeFromJavaArray(grid.data3D()));
-                    support.firePropertyChange(DataWriter.WRITE_COMPLETED, null, null);
                 } catch (IOException | InvalidRangeException e) {
                     logger.warning(e.getMessage());
                     hasErrors.set(true);
@@ -160,7 +160,7 @@ public class NetcdfGridWriter {
             String overwriteErrorMessage = "Failed to overwrite file.";
             String appendErrorMessage = "Some reasons may be:\n* Attempted to append to non-existing variable\n* Attempted to append data with different projection\n* Attempted to append data with different location";
             String message = isAppend ? appendErrorMessage : overwriteErrorMessage;
-            support.firePropertyChange(DataWriter.WRITE_ERROR, null, message);
+            support.firePropertyChange(VortexProperty.ERROR, null, message);
         }
     }
 

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/NetcdfGridWriter.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/NetcdfGridWriter.java
@@ -38,6 +38,7 @@ public class NetcdfGridWriter {
     private static final Logger logger = Logger.getLogger(NetcdfGridWriter.class.getName());
     private final PropertyChangeSupport support = new PropertyChangeSupport(this);
     public static final int BOUNDS_LEN = 2;
+    public static final String CRS_WKT = "crs_wkt";
 
     private final Map<String, VortexGridCollection> gridCollectionMap;
     private final VortexGridCollection defaultCollection;
@@ -253,6 +254,10 @@ public class NetcdfGridWriter {
                     Attribute.builder().setName(name).setValues(Array.makeFromJavaArray(numericValues)).build();
             variableBuilder.addAttribute(attribute);
         }
+
+        // Adding CRS WKT for Grid's Coordinate System information
+        // CF Conventions: https://cfconventions.org/Data/cf-conventions/cf-conventions-1.11/cf-conventions.html#use-of-the-crs-well-known-text-format
+        variableBuilder.addAttribute(new Attribute(CRS_WKT, defaultCollection.getWkt()));
     }
 
     private void addVariableGridCollection(NetcdfFormatWriter.Builder writerBuilder) {

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/NetcdfGridWriter.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/NetcdfGridWriter.java
@@ -58,7 +58,7 @@ public class NetcdfGridWriter {
         lonDim = Dimension.builder().setName(CF.LONGITUDE).setLength(defaultCollection.getNx()).build();
         yDim = Dimension.builder().setName("y").setLength(defaultCollection.getNy()).build();
         xDim = Dimension.builder().setName("x").setLength(defaultCollection.getNx()).build();
-        boundsDim = Dimension.builder().setName("nv").setLength(BOUNDS_LEN).build();
+        boundsDim = Dimension.builder().setName("nv").setIsUnlimited(true).build();
     }
 
     private Map<String, VortexGridCollection> initGridCollectionMap(List<VortexGrid> vortexGridList) {
@@ -335,7 +335,11 @@ public class NetcdfGridWriter {
             int startIndex = timeVar.getShape(0);
             writeVariableGrids(writer, startIndex);
             writer.write(timeVar, new int[] {startIndex}, Array.makeFromJavaArray(defaultCollection.getTimeData()));
-        } catch (IOException | InvalidRangeException e) {
+
+            if (defaultCollection.hasTimeBounds()) {
+                writer.write(getBoundsName(timeDim), new int[] {startIndex, 0}, Array.makeFromJavaArray(defaultCollection.getTimeBoundsArray()));
+            }
+        } catch (Exception e) {
             logger.severe(e.getMessage());
         }
     }

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/VariableDsReader.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/VariableDsReader.java
@@ -1,6 +1,7 @@
 package mil.army.usace.hec.vortex.io;
 
 import mil.army.usace.hec.vortex.VortexGrid;
+import mil.army.usace.hec.vortex.VortexVariable;
 import mil.army.usace.hec.vortex.geo.ReferenceUtils;
 import mil.army.usace.hec.vortex.geo.WktFactory;
 import si.uom.NonSI;
@@ -205,6 +206,9 @@ public class VariableDsReader {
     }
 
     private VortexGrid createDTO(float[] data, ZonedDateTime startTime, ZonedDateTime endTime, Duration interval) {
+        VortexVariable vortexVariable = VortexVariable.fromName(variableDS.getShortName());
+        // FIXME: How about VortexDataType
+
         return VortexGrid.builder()
                 .dx(dx)
                 .dy(dy)
@@ -223,6 +227,7 @@ public class VariableDsReader {
                 .startTime(startTime)
                 .endTime(endTime)
                 .interval(interval)
+                .vortexVariable(vortexVariable)
                 .build();
     }
 

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/math/GridCalculatableUnit.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/math/GridCalculatableUnit.java
@@ -103,21 +103,8 @@ public class GridCalculatableUnit {
 
             float[] calculated = calculator.calculate();
 
-            VortexGrid output = VortexGrid.builder()
-                    .dx(grid.dx()).dy(grid.dy())
-                    .nx(grid.nx()).ny(grid.ny())
-                    .originX(grid.originX())
-                    .originY(grid.originY())
-                    .wkt(grid.wkt())
+            VortexGrid output = grid.toBuilder()
                     .data(calculated)
-                    .units(grid.units())
-                    .fileName(grid.fileName())
-                    .shortName(grid.shortName())
-                    .fullName(grid.fullName())
-                    .description(grid.description())
-                    .startTime(grid.startTime())
-                    .endTime(grid.endTime())
-                    .interval(grid.interval())
                     .build();
 
             List<VortexData> data = new ArrayList<>();

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/math/Normalizer.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/math/Normalizer.java
@@ -263,14 +263,9 @@ public class Normalizer {
                 }
                 outData[i] = value;
             }
-            output.add(VortexGrid.builder()
-                    .dx(dto.dx()).dy(dto.dy()).nx(dto.nx()).ny(dto.ny())
-                    .originX(dto.originX()).originY(dto.originY())
-                    .wkt(dto.wkt()).data(outData).units(dto.units())
-                    .fileName(dto.fileName()).shortName(dto.shortName())
-                    .fullName(dto.fullName()).description(dto.description())
-                    .startTime(dto.startTime()).endTime(dto.endTime())
-                    .interval(dto.interval()).build()
+            output.add(dto.toBuilder()
+                    .data(outData)
+                    .build()
             );
         });
 

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/math/Sanitizer.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/math/Sanitizer.java
@@ -72,21 +72,8 @@ public class Sanitizer {
             }
         }
 
-        return VortexGrid.builder()
-                .dx(input.dx()).dy(input.dy())
-                .nx(input.nx()).ny(input.ny())
-                .originX(input.originX())
-                .originY(input.originY())
-                .wkt(input.wkt())
+        return input.toBuilder()
                 .data(sanitizedData)
-                .units(input.units())
-                .fileName(input.fileName())
-                .shortName(input.shortName())
-                .fullName(input.fullName())
-                .description(input.description())
-                .startTime(input.startTime())
-                .endTime(input.endTime())
-                .interval(input.interval())
                 .build();
     }
 

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/math/Shifter.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/math/Shifter.java
@@ -177,20 +177,7 @@ public class Shifter {
             interval = dto.interval();
         }
 
-        return VortexGrid.builder()
-                .dx(dto.dx())
-                .dy(dto.dy())
-                .nx(dto.nx())
-                .ny(dto.ny())
-                .originX(dto.originX())
-                .originY(dto.originY())
-                .wkt(dto.wkt())
-                .data(dto.data())
-                .units(dto.units())
-                .fileName(dto.fileName())
-                .shortName(dto.shortName())
-                .fullName(dto.shortName())
-                .description(dto.description())
+        return dto.toBuilder()
                 .startTime(shiftedStart)
                 .endTime(shiftedEnd)
                 .interval(interval)

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/util/Stopwatch.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/util/Stopwatch.java
@@ -1,0 +1,39 @@
+package mil.army.usace.hec.vortex.util;
+
+import java.time.Duration;
+import java.time.Instant;
+
+public class Stopwatch {
+    private Instant startTime;
+    private Instant endTime;
+
+    public void start() {
+        if (startTime != null)
+            throw new IllegalStateException("Timer has already started");
+
+        startTime = Instant.now();
+    }
+
+    public void end() {
+        if (endTime != null)
+            throw new IllegalStateException("Timer has already ended");
+
+        endTime = Instant.now();
+    }
+
+    private long getSeconds() {
+        if (startTime == null)
+            throw new IllegalStateException("Timer has not started");
+
+        if (endTime == null)
+            throw new IllegalStateException("Timer has not ended");
+
+        return Duration.between(startTime, endTime).toSeconds();
+    }
+
+    @Override
+    public String toString() {
+        long seconds = getSeconds();
+        return String.format("%d:%02d:%02d%n", seconds / 3600, (seconds % 3600) / 60, (seconds % 60));
+    }
+}

--- a/vortex-api/src/test/java/mil/army/usace/hec/vortex/io/NetcdfDataWriterTest.java
+++ b/vortex-api/src/test/java/mil/army/usace/hec/vortex/io/NetcdfDataWriterTest.java
@@ -1,9 +1,6 @@
 package mil.army.usace.hec.vortex.io;
 
-import mil.army.usace.hec.vortex.TestUtil;
-import mil.army.usace.hec.vortex.VortexData;
-import mil.army.usace.hec.vortex.VortexDataType;
-import mil.army.usace.hec.vortex.VortexGrid;
+import mil.army.usace.hec.vortex.*;
 import mil.army.usace.hec.vortex.geo.WktFactory;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -42,7 +39,8 @@ class NetcdfDataWriterTest {
                     .startTime(time.plusHours(i))
                     .endTime(time.plusHours(i))
                     .interval(Duration.between(time, time))
-                    .dataType(VortexDataType.INSTANTANEOUS)
+                    .vortexVariable(VortexVariable.TEMPERATURE)
+                    .dataType(VortexDataType.AVERAGE)
                     .build();
 
             originalGrids.add(grid);
@@ -95,7 +93,8 @@ class NetcdfDataWriterTest {
                     .startTime(startTime.plusHours(i))
                     .endTime(endTime.plusHours(i))
                     .interval(Duration.between(startTime, endTime))
-                    .dataType(VortexDataType.UNDEFINED)
+                    .vortexVariable(VortexVariable.PRECIPITATION)
+                    .dataType(VortexDataType.ACCUMULATION)
                     .build();
 
             originalGrids.add(grid);

--- a/vortex-api/src/test/java/mil/army/usace/hec/vortex/math/NormalizerTest.java
+++ b/vortex-api/src/test/java/mil/army/usace/hec/vortex/math/NormalizerTest.java
@@ -27,16 +27,19 @@ class NormalizerTest {
         when(dto1.data()).thenReturn(new float[]{0,Float.NaN,2,4,2,2,2,2});
         when(dto1.startTime()).thenReturn(ZonedDateTime.of(0, 1, 1,0,0,0,0, ZoneId.of("UTC")));
         when(dto1.endTime()).thenReturn(ZonedDateTime.of(0, 1, 1,0,0,0,0, ZoneId.of("UTC")));
+        when(dto1.toBuilder()).thenReturn(new VortexGrid.VortexGridBuilder(dto1));
 
         VortexGrid dto2 = mock(VortexGrid.class);
         when(dto2.data()).thenReturn(new float[]{0,2,2,4,2,2,2,1});
         when(dto2.startTime()).thenReturn(ZonedDateTime.of(0, 1, 1,0,0,0,0, ZoneId.of("UTC")));
         when(dto2.endTime()).thenReturn(ZonedDateTime.of(0, 1, 1,0,0,0,0, ZoneId.of("UTC")));
+        when(dto2.toBuilder()).thenReturn(new VortexGrid.VortexGridBuilder(dto2));
 
         VortexGrid dto3 = mock(VortexGrid.class);
         when(dto3.data()).thenReturn(new float[]{0,2,Float.NaN,6,2,8,2,2});
         when(dto3.startTime()).thenReturn(ZonedDateTime.of(0, 1, 1,0,0,0,0, ZoneId.of("UTC")));
         when(dto3.endTime()).thenReturn(ZonedDateTime.of(0, 1, 1,0,0,0,0, ZoneId.of("UTC")));
+        when(dto3.toBuilder()).thenReturn(new VortexGrid.VortexGridBuilder(dto3));
 
         List<VortexGrid> inputs = new ArrayList<>();
         inputs.add(dto1);

--- a/vortex-ui/src/main/java/mil/army/usace/hec/vortex/ui/ImportMetWizard.java
+++ b/vortex-ui/src/main/java/mil/army/usace/hec/vortex/ui/ImportMetWizard.java
@@ -1,9 +1,9 @@
 package mil.army.usace.hec.vortex.ui;
 
 import com.formdev.flatlaf.FlatLightLaf;
+import mil.army.usace.hec.vortex.VortexProperty;
 import mil.army.usace.hec.vortex.io.BatchImporter;
 import mil.army.usace.hec.vortex.io.DataReader;
-import mil.army.usace.hec.vortex.io.DataWriter;
 import mil.army.usace.hec.vortex.ui.util.FileSaveUtil;
 import mil.army.usace.hec.vortex.util.DssUtil;
 
@@ -32,6 +32,7 @@ public class ImportMetWizard extends VortexWizard {
     private Container contentCards;
     private CardLayout cardLayout;
     private JButton backButton, nextButton, cancelButton;
+    private JLabel processingLabel;
     private JProgressBar progressBar;
     private int cardNumber;
 
@@ -193,6 +194,7 @@ public class ImportMetWizard extends VortexWizard {
         destinationSelectionPanel.getFieldF().setText("");
 
         /* Clearing Step Five Panel */
+        processingLabel.setText(TextProperties.getInstance().getProperty("ImportMetWizProcessing_L"));
         progressBar.setIndeterminate(true);
         progressBar.setStringPainted(false);
         progressBar.setValue(0);
@@ -404,21 +406,30 @@ public class ImportMetWizard extends VortexWizard {
                 .build();
 
         importer.addPropertyChangeListener(evt -> {
-            if(evt.getPropertyName().equalsIgnoreCase("progress")) {
-                if(!(evt.getNewValue() instanceof Integer)) return;
+            if (evt.getPropertyName().equals(VortexProperty.STATUS)) {
+                String value = String.valueOf(evt.getNewValue());
+                String message = TextProperties.getInstance().getProperty(value);
+                processingLabel.setText(message);
+            }
+
+            if (evt.getPropertyName().equals(VortexProperty.PROGRESS)) {
+                if (!(evt.getNewValue() instanceof Integer)) return;
                 int progressValue = (int) evt.getNewValue();
                 progressBar.setIndeterminate(false);
                 progressBar.setStringPainted(true);
                 progressBar.setValue(progressValue);
                 progressBar.setString(progressValue + "%");
-                if (progressValue == 100) setImportStatusMessageLabel(true);
             }
 
-            if (evt.getPropertyName().equals(DataWriter.WRITE_ERROR)) {
+            if (evt.getPropertyName().equals(VortexProperty.ERROR)) {
                 String errorMessage = String.valueOf(evt.getNewValue());
                 JOptionPane.showMessageDialog(this, errorMessage,
                         "Error: Failed to write", JOptionPane.ERROR_MESSAGE);
                 setImportStatusMessageLabel(false);
+            }
+
+            if (evt.getPropertyName().equals(VortexProperty.COMPLETE)) {
+                setImportStatusMessageLabel(true);
             }
         });
 
@@ -602,7 +613,7 @@ public class ImportMetWizard extends VortexWizard {
         JPanel insidePanel = new JPanel();
         insidePanel.setLayout(new BoxLayout(insidePanel, BoxLayout.Y_AXIS));
 
-        JLabel processingLabel = new JLabel(TextProperties.getInstance().getProperty("ImportMetWizProcessing_L"));
+        processingLabel = new JLabel(TextProperties.getInstance().getProperty("ImportMetWizProcessing_L"));
         JPanel processingPanel = new JPanel(new FlowLayout(FlowLayout.CENTER));
         processingPanel.add(processingLabel);
         insidePanel.add(processingPanel);

--- a/vortex-ui/src/main/resources/text.properties
+++ b/vortex-ui/src/main/resources/text.properties
@@ -230,3 +230,7 @@ FileOverrideDialogMessage=already exists. Do you want to override it?
 #
 NetcdfGridWriter_OverwriteFailed=Failed to overwrite file.
 NetcdfGridWriter_AppendFailed=Some reasons may be:\n* Attempted to append to non-existing variable\n* Attempted to append data with different projection\n* Attempted to append data with different location
+#
+# Statuses
+#
+ReIndexing=Re-indexing grid cells...


### PR DESCRIPTION
Generalize the properties framework so that more information can be passed to the UI beyond progress, error, and complete. Add VortexProperty class that includes four properties - status, progress, error, and complete. Status updates will update the label in the importer UI.

Set progress based on the number of ImportableUnits that have been processed. This includes a refactor of the SerialBatchImporter which previously used a very memory-intensive approach and did not use ImportableUnits.

Add a Stopwatch utility class for code re-use.