### PR TITLE
Correctly import Livneh unsplit precip data

### DIFF
--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/VortexVariable.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/VortexVariable.java
@@ -83,6 +83,7 @@ public enum VortexVariable {
                 || shortName.equals("pcp")
                 || shortName.equals("pr")
                 || shortName.equals("prec")
+                || shortName.equals("prcp")
                 || shortName.equals("total precipitation");
     }
 

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/DssDataWriter.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/DssDataWriter.java
@@ -363,6 +363,7 @@ public class DssDataWriter extends DataWriter {
                 || descriptionLower.equals("pcp")
                 || descriptionLower.equals("pr")
                 || descriptionLower.equals("prec")
+                || descriptionLower.equals("prcp")
                 || descriptionLower.contains("precip") && descriptionLower.contains("rate")
                 || descriptionLower.contains("precipitable") && descriptionLower.contains("water")
                 || descriptionLower.contains("total") && descriptionLower.contains("precipitation")

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/NetcdfDataReader.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/NetcdfDataReader.java
@@ -376,7 +376,8 @@ public class NetcdfDataReader extends DataReader {
                     zonedDateTimes[0] = convert(tAxis.getCalendarDate(0));
                 } else if (fileName.matches("nldas_fora0125_h.a.*") && variableName.equals("APCP")) {
                     zonedDateTimes[0] = convert(dates[0]).minusHours(1);
-                } else if (fileName.matches("prec.[0-9]{4}.nc")) {
+                } else if (fileName.matches("^prec.[0-9]{4}.nc$") || fileName.matches("^livneh_unsplit_precip.\\d{4}-\\d{2}-\\d{2}.\\d{4}.nc$")) {
+                    // Livneh and Livneh unsplit precipitation data
                     zonedDateTimes[0] = convert(tAxis.getCalendarDate(i));
                 } else if (fileName.matches("gfs.nc")) {
                     zonedDateTimes[0] = convert(dates[0]).plusMinutes(90);
@@ -398,7 +399,8 @@ public class NetcdfDataReader extends DataReader {
                     zonedDateTimes[1] = zonedDateTimes[0].plusHours(1);
                 } else if (fileName.matches("ge.*\\.pgrb2.*\\.0p.*\\.f.*\\..*")) {
                     zonedDateTimes[1] = zonedDateTimes[0].plusHours(3);
-                } else if (fileName.matches("prec.[0-9]{4}.nc")) {
+                } else if (fileName.matches("^prec.[0-9]{4}.nc$") || fileName.matches("^livneh_unsplit_precip.\\d{4}-\\d{2}-\\d{2}.\\d{4}.nc$")) {
+                    // Livneh and Livneh Unsplit precipitation data
                     zonedDateTimes[1] = zonedDateTimes[0].plusDays(1);
                 } else if (fileName.matches("gfs.nc")) {
                     zonedDateTimes[1] = convert(dates[1]).plusMinutes(90);
@@ -513,7 +515,8 @@ public class NetcdfDataReader extends DataReader {
                 "hrrr.*wrfsfcf.*",
                 ".*cmorph.*h.*ly.*",
                 "ge.*\\.pgrb2.*\\.0p.*\\.f.*\\..*",
-                "prec.[0-9]{4}.nc"
+                "prec.[0-9]{4}.nc",
+                "livneh_unsplit_precip.\\d{4}-\\d{2}-\\d{2}.\\d{4}.nc"
         };
 
         if (fileName.matches("nldas_fora0125_h.a.*") && variableName.equals("APCP")


### PR DESCRIPTION
Find files that match the livneh unsplit pattern and interpret them as precipitation data sets.

Resolves: HMS-3671