### PR TITLE
Make DataReader implements AutoClosable

### DIFF
--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/AscDataReader.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/AscDataReader.java
@@ -310,4 +310,9 @@ class AscDataReader extends DataReader {
                 .map(VortexDataInterval::of)
                 .toList();
     }
+
+    @Override
+    public void close() throws Exception {
+        // No op
+    }
 }

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/AscZipDataReader.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/AscZipDataReader.java
@@ -81,4 +81,9 @@ class AscZipDataReader extends DataReader implements VirtualFileSystem {
                 .toList();
     }
 
+    @Override
+    public void close() throws Exception {
+        // No op
+    }
+
 } // AscZipDataReader class

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/BilDataReader.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/BilDataReader.java
@@ -279,4 +279,9 @@ class BilDataReader extends DataReader {
                 .map(VortexDataInterval::of)
                 .toList();
     }
+
+    @Override
+    public void close() throws Exception {
+        // No op
+    }
 } // BilDataReader class

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/BilZipDataReader.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/BilZipDataReader.java
@@ -84,4 +84,8 @@ class BilZipDataReader extends DataReader implements VirtualFileSystem {
                 .toList();
     }
 
+    @Override
+    public void close() throws Exception {
+        // No op
+    }
 } // BilZipDataReader class

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/DataReader.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/DataReader.java
@@ -9,7 +9,7 @@ import java.io.File;
 import java.util.List;
 import java.util.Set;
 
-public abstract class DataReader {
+public abstract class DataReader implements AutoCloseable {
     final PropertyChangeSupport support;
 
     final String path;

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/DssDataReader.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/DssDataReader.java
@@ -1,9 +1,6 @@
 package mil.army.usace.hec.vortex.io;
 
-import hec.heclib.dss.DSSPathname;
-import hec.heclib.dss.DssDataType;
-import hec.heclib.dss.HecDSSDataAttributes;
-import hec.heclib.dss.HecDssCatalog;
+import hec.heclib.dss.*;
 import hec.heclib.grid.GridData;
 import hec.heclib.grid.GridInfo;
 import hec.heclib.grid.GridUtilities;
@@ -43,6 +40,7 @@ class DssDataReader extends DataReader {
         HecDssCatalog hecDssCatalog = new HecDssCatalog();
         hecDssCatalog.setDSSFileName(path);
         String[] dssPathnames = hecDssCatalog.getCatalog(true, variableName);
+        hecDssCatalog.done();
 
         return Arrays.stream(dssPathnames).map(DSSPathname::new).toList();
     }
@@ -73,6 +71,8 @@ class DssDataReader extends DataReader {
             }
         } catch (Exception e) {
             return null;
+        } finally {
+            griddedData.done();
         }
 
         return gridData;
@@ -185,6 +185,8 @@ class DssDataReader extends DataReader {
                 griddedRecords.add(dssPathname);
         }
 
+        attributes.done();
+
         return new HashSet<>(griddedRecords);
     }
 
@@ -223,5 +225,10 @@ class DssDataReader extends DataReader {
                 .map(DSSPathname::toString)
                 .map(VortexDataInterval::of)
                 .toList();
+    }
+
+    @Override
+    public void close() throws Exception {
+        // No op - done() is called on accessors after an opening call is made
     }
 }

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/GridDatasetReader.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/GridDatasetReader.java
@@ -129,6 +129,11 @@ class GridDatasetReader extends NetcdfDataReader {
         return timeBounds;
     }
 
+    @Override
+    public void close() throws Exception {
+        gridDataset.close();
+    }
+
     /* Grid Data Helpers */
     private List<VortexData> getMultiDimensionGrids(Dimension timeDim, Dimension endDim, Dimension rtDim) {
         List<VortexData> gridList = new ArrayList<>();

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/SnodasDataReader.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/SnodasDataReader.java
@@ -296,4 +296,8 @@ class SnodasDataReader extends DataReader {
         return getName(parseFile(pathToDat.substring(0, pathToDat.lastIndexOf(".dat"))));
     }
 
+    @Override
+    public void close() throws Exception {
+        // No op
+    }
 } // SnodasDataReader class

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/SnodasTarDataReader.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/SnodasTarDataReader.java
@@ -204,4 +204,9 @@ class SnodasTarDataReader extends DataReader implements VirtualFileSystem{
 
         return headerFile;
     } // createHeader()
+
+    @Override
+    public void close() throws Exception {
+        // No op
+    }
 } // SnodasTarDataReader class

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/TemporalDataReader.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/TemporalDataReader.java
@@ -14,7 +14,7 @@ import java.util.*;
  * data from a given data source. It supports various operations like reading data
  * for a specific time range and getting grid definitions.
  */
-public class TemporalDataReader {
+public class TemporalDataReader implements AutoCloseable {
     private final DataReader dataReader;
     private final RecordIndexQuery recordIndexQuery;
     private final VortexGrid baseGrid;
@@ -302,5 +302,10 @@ public class TemporalDataReader {
 
             return Integer.compare(o1Count, o2Count);
         };
+    }
+
+    @Override
+    public void close() throws Exception {
+        dataReader.close();
     }
 }

--- a/vortex-api/src/test/java/mil/army/usace/hec/vortex/io/NetcdfDataWriterTest.java
+++ b/vortex-api/src/test/java/mil/army/usace/hec/vortex/io/NetcdfDataWriterTest.java
@@ -18,10 +18,14 @@ import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 class NetcdfDataWriterTest {
+    private static final Logger LOGGER = Logger.getLogger(NetcdfDataWriterTest.class.getName());
+
     @Test
-    void InstantTimeCircleTest() throws IOException {
+    void InstantTimeCircleTest() {
         String outputPath = TestUtil.createTempFile("InstantTimeCircleTest.nc");
         Assertions.assertNotNull(outputPath);
 
@@ -60,22 +64,32 @@ class NetcdfDataWriterTest {
 
         writer.write();
 
-        DataReader reader = DataReader.builder()
+        try (DataReader reader = DataReader.builder()
                 .variable("temperature")
                 .path(outputPath)
-                .build();
+                .build()) {
 
-        List<VortexData> generatedGrids = reader.getDtos();
+            List<VortexData> generatedGrids = reader.getDtos();
 
-        for (int i = 0; i < originalGrids.size(); i++) {
-            Assertions.assertEquals(originalGrids.get(i), generatedGrids.get(i));
+            for (int i = 0; i < originalGrids.size(); i++) {
+                Assertions.assertEquals(originalGrids.get(i), generatedGrids.get(i));
+            }
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, e, e::getMessage);
+            Assertions.fail();
         }
 
-        Files.deleteIfExists(Path.of(outputPath));
+
+        try {
+            Files.deleteIfExists(Path.of(outputPath));
+        } catch (IOException e) {
+            LOGGER.log(Level.SEVERE, e, e::getMessage);
+            Assertions.fail();
+        }
     }
 
     @Test
-    void IntervalTimeCircleTest() throws IOException {
+    void IntervalTimeCircleTest() {
         String outputPath = TestUtil.createTempFile("IntervalTimeCircleTest.nc");
         Assertions.assertNotNull(outputPath);
 
@@ -114,17 +128,26 @@ class NetcdfDataWriterTest {
 
         writer.write();
 
-        DataReader reader = DataReader.builder()
+        try (DataReader reader = DataReader.builder()
                 .variable("precipitation")
                 .path(outputPath)
-                .build();
+                .build()) {
 
-        List<VortexData> generatedGrids = reader.getDtos();
+            List<VortexData> generatedGrids = reader.getDtos();
 
-        for (int i = 0; i < originalGrids.size(); i++) {
-            Assertions.assertEquals(originalGrids.get(i), generatedGrids.get(i));
+            for (int i = 0; i < originalGrids.size(); i++) {
+                Assertions.assertEquals(originalGrids.get(i), generatedGrids.get(i));
+            }
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, e, e::getMessage);
+            Assertions.fail();
         }
 
-        Files.deleteIfExists(Path.of(outputPath));
+        try {
+            Files.deleteIfExists(Path.of(outputPath));
+        } catch (IOException e) {
+            LOGGER.log(Level.SEVERE, e, e::getMessage);
+            Assertions.fail();
+        }
     }
 }

--- a/vortex-api/src/test/java/mil/army/usace/hec/vortex/io/TemporalDataReaderTest.java
+++ b/vortex-api/src/test/java/mil/army/usace/hec/vortex/io/TemporalDataReaderTest.java
@@ -1,5 +1,6 @@
 package mil.army.usace.hec.vortex.io;
 
+import hec.heclib.dss.HecDSSUtilities;
 import hec.heclib.util.Heclib;
 import mil.army.usace.hec.vortex.TestUtil;
 import mil.army.usace.hec.vortex.VortexData;
@@ -11,7 +12,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -483,8 +483,9 @@ class TemporalDataReaderTest {
 
     /* Tear Down */
     @AfterAll
-    static void tearDown() throws IOException {
+    static void tearDown() throws Exception {
         if (tempDssFile != null) {
+            HecDSSUtilities.close(tempDssFile, true);
             Files.deleteIfExists(Path.of(tempDssFile));
         }
     }


### PR DESCRIPTION
Make DataReader implements AutoClosable. Implement close for DssDataReader and NetcdfDataReader. Make TemporalDataReader implements AutoClosable. Update NetcdfDataReader resources to close properly. Update NetcdfDataWriterTest and TemporalDataReaderTest to close resources at tear down.