### PR TITLE
Remove scroll pane from clipping data source text field

### DIFF
--- a/vortex-ui/src/main/java/mil/army/usace/hec/vortex/ui/ImportMetWizard.java
+++ b/vortex-ui/src/main/java/mil/army/usace/hec/vortex/ui/ImportMetWizard.java
@@ -674,10 +674,7 @@ public class ImportMetWizard extends VortexWizard {
 
         dataSourceTextField = new JTextField();
         dataSourceTextField.setFont(addFilesList.getFont());
-        dataSourceTextField.setColumns(0);
-        dataSourceTextField.setBorder(null);
-        JScrollPane layerPanel = new JScrollPane(dataSourceTextField);
-        dataSourceTextFieldPanel.add(layerPanel);
+        dataSourceTextFieldPanel.add(dataSourceTextField);
 
         dataSourceTextFieldPanel.add(Box.createRigidArea(new Dimension(8,0)));
 


### PR DESCRIPTION
Previously, the horizontal scroll pane blocked the user-selected clipping file path if the path was long. This fix removes JScrollPane since JTextField handles scrolling internally.

Resolves: HMS-4082