### PR TITLE
More robust TemporalDataReader for reading period grids

### DIFF
--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/InstantaneousRecordIndexQuery.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/InstantaneousRecordIndexQuery.java
@@ -3,6 +3,7 @@ package mil.army.usace.hec.vortex.io;
 import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.logging.Logger;
+import java.util.stream.Stream;
 
 final class InstantaneousRecordIndexQuery implements RecordIndexQuery {
     private static final Logger logger = Logger.getLogger(InstantaneousRecordIndexQuery.class.getName());
@@ -24,6 +25,16 @@ final class InstantaneousRecordIndexQuery implements RecordIndexQuery {
         } else {
             return queryPeriod(instantaneousDataTree, startTime, endTime);
         }
+    }
+
+    @Override
+    public List<Integer> queryNearest(ZonedDateTime queryTime) {
+        Map.Entry<ZonedDateTime, Integer> floorEntry = instantaneousDataTree.floorEntry(queryTime);
+        Map.Entry<ZonedDateTime, Integer> ceilingEntry = instantaneousDataTree.ceilingEntry(queryTime);
+        return Stream.of(floorEntry, ceilingEntry)
+                .filter(Objects::nonNull)
+                .map(Map.Entry::getValue)
+                .toList();
     }
 
     @Override

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/NoRecordIndexQuery.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/NoRecordIndexQuery.java
@@ -11,6 +11,11 @@ class NoRecordIndexQuery implements RecordIndexQuery {
     }
 
     @Override
+    public List<Integer> queryNearest(ZonedDateTime queryTime) {
+        return Collections.emptyList();
+    }
+
+    @Override
     public ZonedDateTime getEarliestStartTime() {
         return null;
     }

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/PeriodRecordIndexQuery.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/PeriodRecordIndexQuery.java
@@ -27,6 +27,13 @@ final class PeriodRecordIndexQuery implements RecordIndexQuery {
     }
 
     @Override
+    public List<Integer> queryNearest(ZonedDateTime queryTime) {
+        VortexDataInterval interval = VortexDataInterval.of(queryTime, queryTime);
+        List<VortexDataInterval> nearestIntervals = intervalTree.findNearest(interval);
+        return nearestIntervals.stream().map(originalIndexMap::get).toList();
+    }
+
+    @Override
     public ZonedDateTime getEarliestStartTime() {
         return Optional.ofNullable(intervalTree.findMinimum())
                 .map(VortexDataInterval::startTime)

--- a/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/RecordIndexQuery.java
+++ b/vortex-api/src/main/java/mil/army/usace/hec/vortex/io/RecordIndexQuery.java
@@ -8,6 +8,28 @@ import java.util.List;
 interface RecordIndexQuery {
     List<Integer> query(ZonedDateTime startTime, ZonedDateTime endTime);
 
+    /**
+     * Returns the index or indices of the record(s) whose timestamp or interval lies closest to a given instant.
+     * <p>
+     * For point‐in‐time (instantaneous) data, this will return:
+     * <ul>
+     *   <li>the index of the data point at or immediately before {@code queryTime}, and/or</li>
+     *   <li>the index of the data point at or immediately after {@code queryTime}.</li>
+     * </ul>
+     * If the query exactly matches one timestamp, only that single index is returned.
+     * <p>
+     * For period‐based data, this returns the index or indices of the interval(s) whose span is nearest
+     * to the supplied instant (for example, the interval that contains or borders the query time).
+     *
+     * @param queryTime
+     *            the moment in time to search for; must not be {@code null}
+     * @return a list of zero, one, or two record indices that are closest in time to {@code queryTime};
+     *         an empty list if no suitable record is found
+     * @throws NullPointerException
+     *             if {@code queryTime} is {@code null}
+     */
+    List<Integer> queryNearest(ZonedDateTime queryTime);
+
     ZonedDateTime getEarliestStartTime();
 
     ZonedDateTime getLatestEndTime();


### PR DESCRIPTION
**Fix TemporalDataReader::getGridsForPeriod**

The previous implementation of the getGridsForPeriod's filtering logic
had a flaw where it would stop early if the available grids were
disjoint (not contiguous). This caused it to miss relevant grids and
return an incomplete data set.

The new implementation addresses this issue by considering all the
available grids, even if they are not contiguous. It will now correctly
identify and include all the relevant grids in the final result,
providing a more accurate and complete data set.

An example scenario:
- Query for period 1 - 5
- Available grids: [1-2], [3-4], [4-5]
- Previous implementation would only choose [1-2]
- New implementation chooses all grids: [1-2], [3-4], [4-5]

**Add TemporalDataReader::readNearest**
* Implement TemporalDataReader::readNearest, which returns a VortexGrid
whose valid time is closest to the specified queryTime.
* Add unit tests for 'readNearest' in 'TemporalDataReaderTest'